### PR TITLE
Added solution that uses Occurrent

### DIFF
--- a/workshops/introduction-to-event-sourcing/solved/build.gradle
+++ b/workshops/introduction-to-event-sourcing/solved/build.gradle
@@ -18,10 +18,20 @@ dependencies {
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
+  // Occurrent
+  implementation 'org.occurrent:application-service-blocking:0.14.4'
+  implementation 'org.occurrent:cloudevent-converter-jackson:0.14.4'
+  implementation 'org.occurrent:eventstore-inmemory:0.14.4'
+  implementation 'org.occurrent:query-dsl-blocking:0.14.4'
+  implementation 'org.occurrent:command-composition:0.14.4'
+
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
   implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
   implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+
+  // Stream
+  implementation 'one.util:streamex:0.8.1'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
@@ -29,6 +39,7 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 
 tasks.named('test') {

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/occurrent/README.md
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/occurrent/README.md
@@ -1,0 +1,21 @@
+# Exercise 04 - Getting the current entity state from events using Occurrent
+
+Having a defined structure of events and an entity representing the shopping cart from the [first exercise](../../e01_events_definition), fill a `getShoppingCart` function that will rebuild the current state from events.
+
+If needed you can modify the events or entity structure.
+
+There are two variations:
+- using mutable entities: [Mutable/GettingStateFromEventsTests.java](./mutable/GettingStateFromEventsTests.java),
+- using fully immutable structures: [Immutable/Solution1/GettingStateFromEventsTests.java](./immutable/solution2/GettingStateFromEventsTests.java).
+
+Select your preferred approach (or both) to solve this use case. If needed you can modify entities or events.
+
+## Solution
+
+Read also my articles:
+- [How to get the current entity state from events?](https://event-driven.io/en/how_to_get_the_current_entity_state_in_event_sourcing/?utm_source=event_sourcing_java_workshop).
+- [Should you throw an exception when rebuilding the state from events?](https://event-driven.io/en/should_you_throw_exception_when_rebuilding_state_from_events/=event_sourcing_java_workshop)
+- and [Occurrent documentation on reading events](https://occurrent.org/documentation#eventstream)
+
+2. Immutable:
+- second: [immutable/GettingStateFromEventsTests.java](./immutable/GettingStateFromEventsTests.java).

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/occurrent/immutable/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/occurrent/immutable/GettingStateFromEventsTests.java
@@ -1,0 +1,264 @@
+package io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.occurrent.immutable;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import one.util.streamex.StreamEx;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import static io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.occurrent.immutable.GettingStateFromEventsTests.ShoppingCartEvent.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.occurrent.filter.Filter.streamId;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class GettingStateFromEventsTests {
+
+  private DomainEventQueries<ShoppingCartEvent> eventQueries;
+
+  private InMemoryEventStore eventStore;
+  private CloudEventConverter<ShoppingCartEvent> cloudEventConverter;
+
+  @BeforeEach
+  void setup() {
+    var objectMapper = new JsonMapper()
+      .registerModule(new JavaTimeModule())
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+    eventStore = new InMemoryEventStore();
+    cloudEventConverter = new JacksonCloudEventConverter<>(objectMapper, URI.create("urn:eventsourcing:jvm:samples:occurrent"));
+    eventQueries = new DomainEventQueries<>(eventStore, cloudEventConverter);
+  }
+
+  public sealed interface ShoppingCartEvent {
+    record ShoppingCartOpened(
+      UUID shoppingCartId,
+      UUID clientId
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemAddedToShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemRemovedFromShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartConfirmed(
+      UUID shoppingCartId,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartCanceled(
+      UUID shoppingCartId,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCartEvent {
+    }
+  }
+
+  public record PricedProductItem(
+    UUID productId,
+    int quantity,
+    double unitPrice
+  ) {
+    public double totalAmount() {
+      return quantity * unitPrice;
+    }
+  }
+
+  public record ProductItems(
+    PricedProductItem[] values
+  ) {
+    public static ProductItems empty() {
+      return new ProductItems(new PricedProductItem[]{});
+    }
+
+    public ProductItems add(PricedProductItem productItem) {
+      return new ProductItems(
+        StreamEx.of(values)
+          .append(productItem)
+          .groupingBy(PricedProductItem::productId)
+          .entrySet().stream()
+          .map(group -> group.getValue().size() == 1 ?
+            group.getValue().get(0) :
+            new PricedProductItem(
+              group.getKey(),
+              group.getValue().stream().mapToInt(PricedProductItem::quantity).sum(),
+              group.getValue().get(0).unitPrice()
+            )
+          )
+          .toArray(PricedProductItem[]::new)
+      );
+    }
+
+    public ProductItems remove(PricedProductItem productItem) {
+      return new ProductItems(
+        Arrays.stream(values())
+          .map(pi -> pi.productId().equals(productItem.productId()) ?
+            new PricedProductItem(
+              pi.productId(),
+              pi.quantity() - productItem.quantity(),
+              pi.unitPrice()
+            )
+            : pi
+          )
+          .filter(pi -> pi.quantity > 0)
+          .toArray(PricedProductItem[]::new)
+      );
+    }
+  }
+
+  // ENTITY
+  sealed public interface ShoppingCart {
+    UUID id();
+
+    UUID clientId();
+
+    ProductItems productItems();
+
+    record PendingShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems
+    ) implements ShoppingCart {
+    }
+
+    record ConfirmedShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCart {
+    }
+
+    record CanceledShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCart {
+    }
+
+    default ShoppingCartStatus status() {
+      return switch (this) {
+        case PendingShoppingCart ignored:
+          yield ShoppingCartStatus.Pending;
+        case ConfirmedShoppingCart ignored:
+          yield ShoppingCartStatus.Confirmed;
+        case CanceledShoppingCart ignored:
+          yield ShoppingCartStatus.Canceled;
+      };
+    }
+
+    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+      return switch (event) {
+        case ShoppingCartOpened shoppingCartOpened:
+          yield new PendingShoppingCart(
+            shoppingCartOpened.shoppingCartId(),
+            shoppingCartOpened.clientId(),
+            ProductItems.empty()
+          );
+        case ProductItemAddedToShoppingCart productItemAddedToShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().add(productItemAddedToShoppingCart.productItem())
+          );
+        case ProductItemRemovedFromShoppingCart productItemRemovedFromShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().remove(productItemRemovedFromShoppingCart.productItem())
+          );
+        case ShoppingCartConfirmed shoppingCartConfirmed:
+          yield new ConfirmedShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartConfirmed.confirmedAt()
+          );
+        case ShoppingCartCanceled shoppingCartCanceled:
+          yield new CanceledShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartCanceled.canceledAt()
+          );
+      };
+    }
+
+    static ShoppingCart empty() {
+      return new PendingShoppingCart(null, null, null);
+    }
+  }
+
+  public enum ShoppingCartStatus {
+    Pending,
+    Confirmed,
+    Canceled
+  }
+
+  ShoppingCart getShoppingCart(String streamName) {
+    // 1. Add logic here
+    return StreamEx.of(eventQueries.query(streamId(streamName)))
+      .foldLeft(ShoppingCart.empty(), ShoppingCart::when);
+  }
+
+  @Test
+  public void gettingState_ForSequenceOfEvents_ShouldSucceed() throws ExecutionException, InterruptedException {
+    var shoppingCartId = UUID.randomUUID();
+    var clientId = UUID.randomUUID();
+    var shoesId = UUID.randomUUID();
+    var tShirtId = UUID.randomUUID();
+    var twoPairsOfShoes = new PricedProductItem(shoesId, 2, 100);
+    var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
+    var tShirt = new PricedProductItem(tShirtId, 1, 50);
+
+    var events = Stream.of(
+      new ShoppingCartOpened(shoppingCartId, clientId),
+      new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
+      new ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
+      new ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
+      new ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
+      new ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
+    ).map(cloudEventConverter::toCloudEvent);
+
+    var streamName = "shopping_cart-%s".formatted(shoppingCartId);
+
+    eventStore.write(streamName, events);
+
+    var shoppingCart = getShoppingCart(streamName);
+
+    assertAll(
+      () -> assertThat(shoppingCart.id()).isEqualTo(shoppingCartId),
+      () -> assertThat(shoppingCart.clientId()).isEqualTo(clientId),
+      () -> assertThat(shoppingCart.productItems().values).hasSize(2),
+      () -> assertThat(shoppingCart.productItems().values()).startsWith(pairOfShoes, tShirt)
+    );
+  }
+}

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution1/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution1/BusinessLogic.java
@@ -1,0 +1,146 @@
+package io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1;
+
+import io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogicTests.PricedProductItem;
+import io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogicTests.ProductItem;
+import io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogicTests.ShoppingCart;
+import io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogicTests.ShoppingCartEvent;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogic.ShoppingCartCommand.*;
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogicTests.ShoppingCartEvent.*;
+
+public class BusinessLogic {
+  public sealed interface ShoppingCartCommand {
+    record OpenShoppingCart(
+      UUID shoppingCartId,
+      UUID clientId
+    ) implements ShoppingCartCommand {
+    }
+
+    record AddProductItemToShoppingCart(
+      UUID shoppingCartId,
+      ProductItem productItem
+    ) implements ShoppingCartCommand {
+    }
+
+    record RemoveProductItemFromShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartCommand {
+    }
+
+    record ConfirmShoppingCart(
+      UUID shoppingCartId
+    ) implements ShoppingCartCommand {
+    }
+
+    record CancelShoppingCart(
+      UUID shoppingCartId
+    ) implements ShoppingCartCommand {
+    }
+  }
+
+  public static class ShoppingCartCommandHandler {
+    public static ShoppingCartEvent decide(
+      Supplier<ProductPriceCalculator> getProductPriceCalculator,
+      ShoppingCartCommand command,
+      ShoppingCart entity
+    ) {
+      return switch (command) {
+        case OpenShoppingCart openCommand ->
+          open(openCommand);
+        case AddProductItemToShoppingCart addCommand ->
+          addProductItem(getProductPriceCalculator.get(), addCommand, entity);
+        case RemoveProductItemFromShoppingCart removeProductCommand ->
+          removeProductItem(removeProductCommand, entity);
+        case ConfirmShoppingCart confirmCommand ->
+          confirm(confirmCommand, entity);
+        case CancelShoppingCart cancelCommand ->
+          cancel(cancelCommand, entity);
+      };
+    }
+
+    public static ShoppingCartOpened open(OpenShoppingCart command) {
+      return new ShoppingCartOpened(
+        command.shoppingCartId(),
+        command.clientId()
+      );
+    }
+
+    public static ProductItemAddedToShoppingCart addProductItem(
+      ProductPriceCalculator productPriceCalculator,
+      AddProductItemToShoppingCart command,
+      ShoppingCart shoppingCart
+    ) {
+      if (shoppingCart.isClosed())
+        throw new IllegalStateException("Removing product item for cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+      var pricedProductItem = productPriceCalculator.calculate(command.productItem);
+
+      shoppingCart.productItems().add(pricedProductItem);
+
+      return new ProductItemAddedToShoppingCart(
+        command.shoppingCartId,
+        pricedProductItem
+      );
+    }
+
+    public static ProductItemRemovedFromShoppingCart removeProductItem(
+      RemoveProductItemFromShoppingCart command,
+      ShoppingCart shoppingCart
+    ) {
+      if (shoppingCart.isClosed())
+        throw new IllegalStateException("Adding product item for cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+      shoppingCart.productItems().hasEnough(command.productItem());
+
+      return new ProductItemRemovedFromShoppingCart(
+        command.shoppingCartId(),
+        command.productItem()
+      );
+    }
+
+    public static ShoppingCartConfirmed confirm(ConfirmShoppingCart command, ShoppingCart shoppingCart) {
+      if (shoppingCart.isClosed())
+        throw new IllegalStateException("Confirming cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+      return new ShoppingCartConfirmed(
+        shoppingCart.id(),
+        OffsetDateTime.now()
+      );
+    }
+
+    public static ShoppingCartCanceled cancel(CancelShoppingCart command, ShoppingCart shoppingCart) {
+      if (shoppingCart.isClosed())
+        throw new IllegalStateException("Canceling cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+      return new ShoppingCartCanceled(
+        shoppingCart.id(),
+        OffsetDateTime.now()
+      );
+    }
+  }
+
+  public interface ProductPriceCalculator {
+    PricedProductItem calculate(ProductItem productItems);
+  }
+
+  public static class FakeProductPriceCalculator implements ProductPriceCalculator {
+    private final double value;
+
+    private FakeProductPriceCalculator(double value) {
+      this.value = value;
+    }
+
+    public static FakeProductPriceCalculator returning(double value) {
+      return new FakeProductPriceCalculator(value);
+    }
+
+    public PricedProductItem calculate(ProductItem productItem) {
+      return new PricedProductItem(productItem.productId(), productItem.quantity(), value);
+    }
+  }
+}

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution1/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution1/BusinessLogicTests.java
@@ -1,0 +1,316 @@
+package io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import one.util.streamex.StreamEx;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.application.service.blocking.generic.GenericApplicationService;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogic.*;
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogic.ShoppingCartCommand.*;
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1.BusinessLogicTests.ShoppingCartEvent.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.occurrent.filter.Filter.streamId;
+
+public class BusinessLogicTests {
+  private DomainEventQueries<ShoppingCartEvent> eventQueries;
+
+  private InMemoryEventStore eventStore;
+  private CloudEventConverter<ShoppingCartEvent> cloudEventConverter;
+  private ApplicationService<ShoppingCartEvent> applicationService;
+
+  @BeforeEach
+  void setup() {
+    var objectMapper = new JsonMapper()
+      .registerModule(new JavaTimeModule())
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+    eventStore = new InMemoryEventStore();
+    cloudEventConverter = new JacksonCloudEventConverter<>(objectMapper, URI.create("urn:eventsourcing:jvm:samples:occurrent"));
+    eventQueries = new DomainEventQueries<>(eventStore, cloudEventConverter);
+    applicationService = new GenericApplicationService<>(eventStore, cloudEventConverter);
+  }
+
+  public sealed interface ShoppingCartEvent {
+    record ShoppingCartOpened(
+      UUID shoppingCartId,
+      UUID clientId
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemAddedToShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemRemovedFromShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartConfirmed(
+      UUID shoppingCartId,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartCanceled(
+      UUID shoppingCartId,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCartEvent {
+    }
+  }
+
+  public record PricedProductItem(
+    UUID productId,
+    int quantity,
+    double unitPrice
+  ) {
+    public double totalAmount() {
+      return quantity * unitPrice;
+    }
+  }
+
+  public record ProductItem(
+    UUID productId,
+    int quantity) {
+  }
+
+  public record ProductItems(
+    PricedProductItem[] values
+  ) {
+    public static ProductItems empty() {
+      return new ProductItems(new PricedProductItem[]{});
+    }
+
+    public ProductItems add(PricedProductItem productItem) {
+      return new ProductItems(
+        StreamEx.of(values).append(productItem)
+          .groupingBy(PricedProductItem::productId)
+          .entrySet().stream()
+          .map(group -> group.getValue().size() == 1 ?
+            group.getValue().get(0) :
+            new PricedProductItem(
+              group.getKey(),
+              group.getValue().stream().mapToInt(PricedProductItem::quantity).sum(),
+              group.getValue().get(0).unitPrice()
+            )
+          )
+          .toArray(PricedProductItem[]::new)
+      );
+    }
+
+    public ProductItems remove(PricedProductItem productItem) {
+      return new ProductItems(
+        Arrays.stream(values())
+          .map(pi -> pi.productId().equals(productItem.productId()) ?
+            new PricedProductItem(
+              pi.productId(),
+              pi.quantity() - productItem.quantity(),
+              pi.unitPrice()
+            )
+            : pi
+          )
+          .filter(pi -> pi.quantity > 0)
+          .toArray(PricedProductItem[]::new)
+      );
+    }
+
+    public boolean hasEnough(PricedProductItem productItem) {
+      var currentQuantity = Arrays.stream(values)
+        .filter(pi -> pi.productId().equals(productItem.productId()))
+        .mapToInt(PricedProductItem::quantity)
+        .sum();
+
+      return currentQuantity >= productItem.quantity();
+    }
+  }
+
+  // ENTITY
+  sealed public interface ShoppingCart {
+    UUID id();
+
+    UUID clientId();
+
+    ProductItems productItems();
+
+    record PendingShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems
+    ) implements ShoppingCart {
+    }
+
+    record ConfirmedShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCart {
+    }
+
+    record CanceledShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCart {
+    }
+
+    default ShoppingCartStatus status() {
+      return switch (this) {
+        case PendingShoppingCart ignored:
+          yield ShoppingCartStatus.Pending;
+        case ConfirmedShoppingCart ignored:
+          yield ShoppingCartStatus.Confirmed;
+        case CanceledShoppingCart ignored:
+          yield ShoppingCartStatus.Canceled;
+      };
+    }
+
+    default boolean isClosed() {
+      return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
+    }
+
+    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+      return switch (event) {
+        case ShoppingCartOpened shoppingCartOpened:
+          yield new PendingShoppingCart(
+            shoppingCartOpened.shoppingCartId(),
+            shoppingCartOpened.clientId(),
+            ProductItems.empty()
+          );
+        case ProductItemAddedToShoppingCart productItemAddedToShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().add(productItemAddedToShoppingCart.productItem())
+          );
+        case ProductItemRemovedFromShoppingCart productItemRemovedFromShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().remove(productItemRemovedFromShoppingCart.productItem())
+          );
+        case ShoppingCartConfirmed shoppingCartConfirmed:
+          yield new ConfirmedShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartConfirmed.confirmedAt()
+          );
+        case ShoppingCartCanceled shoppingCartCanceled:
+          yield new CanceledShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartCanceled.canceledAt()
+          );
+      };
+    }
+
+    static ShoppingCart empty() {
+      return new PendingShoppingCart(null, null, null);
+    }
+  }
+
+  public enum ShoppingCartStatus {
+    Pending,
+    Confirmed,
+    Canceled
+  }
+
+  @Test
+  public void gettingState_ForSequenceOfEvents_ShouldSucceed() {
+    var shoppingCartId = UUID.randomUUID();
+    var clientId = UUID.randomUUID();
+    var shoesId = UUID.randomUUID();
+    var tShirtId = UUID.randomUUID();
+
+    var twoPairsOfShoes = new ProductItem(shoesId, 2);
+    var pairOfShoes = new ProductItem(shoesId, 1);
+    var tShirt = new ProductItem(tShirtId, 1);
+
+    var shoesPrice = 100;
+    var tShirtPrice = 50;
+
+    var pricedPairOfShoes = new PricedProductItem(shoesId, 1, shoesPrice);
+    var pricedTShirt = new PricedProductItem(tShirtId, 1, tShirtPrice);
+
+    var handle =
+      CommandHandler.<ShoppingCart, ShoppingCartEvent, ShoppingCartCommand>commandHandler(
+        applicationService,
+        ShoppingCart::empty,
+        "shopping_cart-%s"::formatted,
+        ShoppingCart::when,
+        (command, entity) -> ShoppingCartCommandHandler.decide(
+          () -> command instanceof AddProductItemToShoppingCart addProduct ?
+            FakeProductPriceCalculator.returning(addProduct.productItem() == twoPairsOfShoes ? shoesPrice : tShirtPrice)
+            : null,
+          command,
+          entity
+        )
+      );
+
+
+    // Open
+    var openShoppingCart = new OpenShoppingCart(shoppingCartId, clientId);
+    handle.accept(openShoppingCart.shoppingCartId(), openShoppingCart);
+
+
+    // Add two pairs of shoes
+    var addTwoPairsOfShoes = new AddProductItemToShoppingCart(shoppingCartId, twoPairsOfShoes);
+    handle.accept(addTwoPairsOfShoes.shoppingCartId(), addTwoPairsOfShoes);
+
+    // Add T-Shirt
+    var addTShirt = new AddProductItemToShoppingCart(shoppingCartId, tShirt);
+    handle.accept(addTShirt.shoppingCartId(), addTShirt);
+
+    // Remove pair of shoes
+    var removePairOfShoes = new RemoveProductItemFromShoppingCart(shoppingCartId, pricedPairOfShoes);
+    handle.accept(removePairOfShoes.shoppingCartId(), removePairOfShoes);
+
+    // Confirm
+    var confirmShoppingCart = new ConfirmShoppingCart(shoppingCartId);
+    handle.accept(confirmShoppingCart.shoppingCartId(), confirmShoppingCart);
+
+    // Cancel
+    assertThrows(IllegalStateException.class, () -> {
+      var cancelShoppingCart = new CancelShoppingCart(shoppingCartId);
+      handle.accept(cancelShoppingCart.shoppingCartId(), cancelShoppingCart);
+    });
+
+
+    var shoppingCart = StreamEx.of(eventQueries.query(streamId("shopping_cart-%s".formatted(shoppingCartId))))
+      .foldLeft(ShoppingCart.empty(), ShoppingCart::when);
+
+    assertAll(
+      () -> assertThat(shoppingCart.id()).isEqualTo(shoppingCartId),
+      () -> assertThat(shoppingCart.clientId()).isEqualTo(clientId),
+      () -> assertThat(shoppingCart.productItems().values()).hasSize(2),
+      () -> assertThat(shoppingCart.status()).isEqualTo(ShoppingCartStatus.Confirmed),
+      () -> assertThat(shoppingCart.productItems().values()).startsWith(pricedPairOfShoes, pricedTShirt)
+    );
+  }
+}

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution1/CommandHandler.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution1/CommandHandler.java
@@ -1,0 +1,31 @@
+package io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution1;
+
+import one.util.streamex.StreamEx;
+import org.occurrent.application.service.blocking.ApplicationService;
+
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public final class CommandHandler {
+
+  public static <Entity, Event, Command> BiConsumer<UUID, Command> commandHandler(
+    ApplicationService<Event> applicationService,
+    Supplier<Entity> getEmpty,
+    Function<UUID, String> toStreamName,
+    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Command, Entity, Event> handle
+  ) {
+    return (id, command) -> {
+      var streamName = toStreamName.apply(id);
+
+      applicationService.execute(streamName, e -> {
+        var entity = StreamEx.of(e).foldLeft(getEmpty.get(), when);
+        return Stream.of(handle.apply(command, entity));
+      });
+    };
+  }
+}

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution2/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution2/BusinessLogic.java
@@ -1,0 +1,277 @@
+package io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution2;
+
+import one.util.streamex.StreamEx;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution2.BusinessLogic.ShoppingCartEvent.*;
+
+public class BusinessLogic {
+
+  public sealed interface ShoppingCartEvent {
+    record ShoppingCartOpened(
+      UUID shoppingCartId,
+      UUID clientId
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemAddedToShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemRemovedFromShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartConfirmed(
+      UUID shoppingCartId,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartCanceled(
+      UUID shoppingCartId,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCartEvent {
+    }
+  }
+
+  public static ShoppingCartOpened open(ShoppingCart shoppingCart, UUID shoppingCartId, UUID clientId) {
+    if (shoppingCart.isClosed()) {
+      throw new IllegalStateException("Cannot open a closed shopping cart");
+    }
+    return new ShoppingCartOpened(
+      shoppingCartId,
+      clientId
+    );
+  }
+
+  public static ProductItemAddedToShoppingCart addProductItem(
+    ShoppingCart shoppingCart,
+    ProductItem productItem,
+    ProductPriceCalculator productPriceCalculator
+  ) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Removing product item for cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    var pricedProductItem = productPriceCalculator.calculate(productItem);
+
+    shoppingCart.productItems().add(pricedProductItem);
+
+    return new ProductItemAddedToShoppingCart(
+      shoppingCart.id(),
+      pricedProductItem
+    );
+  }
+
+  public static ProductItemRemovedFromShoppingCart removeProductItem(ShoppingCart shoppingCart, PricedProductItem productItem) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Adding product item for cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    shoppingCart.productItems().hasEnough(productItem);
+
+    return new ProductItemRemovedFromShoppingCart(
+      shoppingCart.id(),
+      productItem
+    );
+  }
+
+  public static ShoppingCartConfirmed confirm(ShoppingCart shoppingCart) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Confirming cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    return new ShoppingCartConfirmed(
+      shoppingCart.id(),
+      OffsetDateTime.now()
+    );
+  }
+
+  public static ShoppingCartCanceled cancel(ShoppingCart shoppingCart) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Canceling cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    return new ShoppingCartCanceled(
+      shoppingCart.id(),
+      OffsetDateTime.now()
+    );
+  }
+
+  interface ProductPriceCalculator {
+    PricedProductItem calculate(ProductItem productItems);
+  }
+
+  static class FakeProductPriceCalculator implements ProductPriceCalculator {
+    private final double value;
+
+    private FakeProductPriceCalculator(double value) {
+      this.value = value;
+    }
+
+    public static FakeProductPriceCalculator returning(double value) {
+      return new FakeProductPriceCalculator(value);
+    }
+
+    public PricedProductItem calculate(ProductItem productItem) {
+      return new PricedProductItem(productItem.productId(), productItem.quantity(), value);
+    }
+  }
+
+
+  sealed public interface ShoppingCart {
+    UUID id();
+
+    UUID clientId();
+
+    ProductItems productItems();
+
+    record PendingShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems
+    ) implements ShoppingCart {
+    }
+
+    record ConfirmedShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCart {
+    }
+
+    record CanceledShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCart {
+    }
+
+    enum ShoppingCartStatus {
+      Pending,
+      Confirmed,
+      Canceled
+    }
+
+    default ShoppingCartStatus status() {
+      return switch (this) {
+        case PendingShoppingCart ignored:
+          yield ShoppingCartStatus.Pending;
+        case ConfirmedShoppingCart ignored:
+          yield ShoppingCartStatus.Confirmed;
+        case CanceledShoppingCart ignored:
+          yield ShoppingCartStatus.Canceled;
+      };
+    }
+
+    default boolean isClosed() {
+      return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
+    }
+
+    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+      return switch (event) {
+        case ShoppingCartOpened shoppingCartOpened:
+          yield new PendingShoppingCart(
+            shoppingCartOpened.shoppingCartId(),
+            shoppingCartOpened.clientId(),
+            ProductItems.empty()
+          );
+        case ProductItemAddedToShoppingCart productItemAddedToShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().add(productItemAddedToShoppingCart.productItem())
+          );
+        case ProductItemRemovedFromShoppingCart productItemRemovedFromShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().remove(productItemRemovedFromShoppingCart.productItem())
+          );
+        case ShoppingCartConfirmed shoppingCartConfirmed:
+          yield new ConfirmedShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartConfirmed.confirmedAt()
+          );
+        case ShoppingCartCanceled shoppingCartCanceled:
+          yield new CanceledShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartCanceled.canceledAt()
+          );
+      };
+    }
+
+    static ShoppingCart empty() {
+      return new PendingShoppingCart(null, null, null);
+    }
+  }
+
+  record ProductItem(UUID productId, int quantity) {
+  }
+
+  record PricedProductItem(UUID productId, int quantity, double unitPrice) {
+    public double totalAmount() {
+      return quantity * unitPrice;
+    }
+  }
+
+  record ProductItems(PricedProductItem[] values) {
+    public static ProductItems empty() {
+      return new ProductItems(new PricedProductItem[]{});
+    }
+
+
+    public ProductItems add(PricedProductItem productItem) {
+      // Note that we cannot simply group by product item id since the order of entries().stream().is arbitrary.
+      boolean containsProduct = Arrays.stream(values).anyMatch(pricedProductItem -> pricedProductItem.productId.equals(productItem.productId));
+      final Stream<PricedProductItem> resultingStream;
+      if (containsProduct) {
+        resultingStream = Arrays.stream(values)
+          .map(pricedProductItem -> new PricedProductItem(
+            pricedProductItem.productId,
+            pricedProductItem.quantity + productItem.quantity,
+            pricedProductItem.unitPrice));
+      } else {
+        resultingStream = StreamEx.of(values).append(productItem);
+      }
+      return new ProductItems(resultingStream.toArray(PricedProductItem[]::new));
+    }
+
+    public ProductItems remove(PricedProductItem productItem) {
+      return new ProductItems(
+        Arrays.stream(values())
+          .map(pi -> pi.productId().equals(productItem.productId()) ?
+            new PricedProductItem(
+              pi.productId(),
+              pi.quantity() - productItem.quantity(),
+              pi.unitPrice()
+            )
+            : pi
+          )
+          .filter(pi -> pi.quantity() > 0)
+          .toArray(PricedProductItem[]::new)
+      );
+    }
+
+    public boolean hasEnough(PricedProductItem productItem) {
+      var currentQuantity = Arrays.stream(values)
+        .filter(pi -> pi.productId().equals(productItem.productId()))
+        .mapToInt(PricedProductItem::quantity)
+        .sum();
+
+      return currentQuantity >= productItem.quantity();
+    }
+  }
+}
+

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution2/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/occurrent/immutable/solution2/BusinessLogicTests.java
@@ -1,0 +1,109 @@
+package io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution2;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution2.BusinessLogic.ShoppingCart.ShoppingCartStatus;
+import one.util.streamex.StreamEx;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.application.service.blocking.generic.GenericApplicationService;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static io.eventdriven.introductiontoeventsourcing.e06_business_logic.occurrent.immutable.solution2.BusinessLogic.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.occurrent.application.composition.command.StreamCommandComposition.composeCommands;
+import static org.occurrent.application.composition.command.partial.PartialFunctionApplication.partial;
+import static org.occurrent.filter.Filter.streamId;
+
+public class BusinessLogicTests {
+  private DomainEventQueries<ShoppingCartEvent> eventQueries;
+
+  private ApplicationService<ShoppingCartEvent> applicationService;
+
+  @BeforeEach
+  void setup() {
+    var objectMapper = new JsonMapper()
+      .registerModule(new JavaTimeModule())
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+    var eventStore = new InMemoryEventStore();
+    CloudEventConverter<ShoppingCartEvent> cloudEventConverter = new JacksonCloudEventConverter<>(objectMapper, URI.create("urn:eventsourcing:jvm:samples:occurrent"));
+    eventQueries = new DomainEventQueries<>(eventStore, cloudEventConverter);
+    applicationService = new GenericApplicationService<>(eventStore, cloudEventConverter);
+  }
+
+
+  @Test
+  public void gettingState_ForSequenceOfEvents_ShouldSucceed() {
+    var shoppingCartId = UUID.randomUUID();
+    var clientId = UUID.randomUUID();
+    var shoesId = UUID.randomUUID();
+    var tShirtId = UUID.randomUUID();
+
+    var twoPairsOfShoes = new ProductItem(shoesId, 2);
+    var tShirt = new ProductItem(tShirtId, 1);
+
+    var shoesPrice = 100;
+    var tShirtPrice = 50;
+
+    var pricedPairOfShoes = new PricedProductItem(shoesId, 1, shoesPrice);
+    var pricedTShirt = new PricedProductItem(tShirtId, 1, tShirtPrice);
+
+    String streamId = "shopping_cart-%s".formatted(shoppingCartId);
+
+    applicationService.execute(streamId, compose(
+      partial(BusinessLogic::open, shoppingCartId, clientId),
+      partial(BusinessLogic::addProductItem, twoPairsOfShoes, FakeProductPriceCalculator.returning(shoesPrice)),
+      partial(BusinessLogic::addProductItem, tShirt, FakeProductPriceCalculator.returning(tShirtPrice)),
+      partial(BusinessLogic::removeProductItem, pricedPairOfShoes),
+      BusinessLogic::confirm
+    ));
+
+    var shoppingCart = StreamEx.of(eventQueries.query(streamId(streamId))).foldLeft(ShoppingCart.empty(), ShoppingCart::when);
+
+    assertAll(
+      () -> assertThat(shoppingCart.id()).isEqualTo(shoppingCartId),
+      () -> assertThat(shoppingCart.clientId()).isEqualTo(clientId),
+      () -> assertThat(shoppingCart.status()).isEqualTo(ShoppingCartStatus.Confirmed),
+      () -> assertThat(shoppingCart.productItems().values()).containsExactly(pricedPairOfShoes, pricedTShirt)
+    );
+  }
+
+  /**
+   * A function that transforms domain functions that take a ShoppingCart and returns a single ShoppingCartEvent
+   * into functions that takes a <code>Stream&lt;ShoppingCartEvent&gt;</code> and returns a <code>Stream&lt;ShoppingCartEvent&gt;</code>
+   * because this is what Occurrent expects.
+   * <p>
+   * You can make this function generic (and thus reusable for all use domains and use cases) if you wish,
+   * but we keep it concrete and simple for now.
+   */
+  @SafeVarargs
+  private static Function<Stream<ShoppingCartEvent>, Stream<ShoppingCartEvent>> compose(Function<ShoppingCart, ShoppingCartEvent>... domainMethods) {
+    Stream<Function<Stream<ShoppingCartEvent>, Stream<ShoppingCartEvent>>> functionsToInvoke =
+      Stream.of(domainMethods)
+        .map(domainMethod -> events -> {
+          ShoppingCart shoppingCart = StreamEx.of(events)
+            .foldLeft(ShoppingCart.empty(), ShoppingCart::when);
+          ShoppingCartEvent newEvent = domainMethod.apply(shoppingCart);
+          return Stream.of(newEvent);
+        });
+
+    return composeCommands(functionsToInvoke);
+  }
+}

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/occurrent/immutable/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/occurrent/immutable/BusinessLogic.java
@@ -1,0 +1,277 @@
+package io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable;
+
+import one.util.streamex.StreamEx;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.ShoppingCartEvent.*;
+
+public class BusinessLogic {
+
+  public sealed interface ShoppingCartEvent {
+    record ShoppingCartOpened(
+      UUID shoppingCartId,
+      UUID clientId
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemAddedToShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ProductItemRemovedFromShoppingCart(
+      UUID shoppingCartId,
+      PricedProductItem productItem
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartConfirmed(
+      UUID shoppingCartId,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCartEvent {
+    }
+
+    record ShoppingCartCanceled(
+      UUID shoppingCartId,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCartEvent {
+    }
+  }
+
+  public static ShoppingCartOpened open(ShoppingCart shoppingCart, UUID shoppingCartId, UUID clientId) {
+    if (shoppingCart.isClosed()) {
+      throw new IllegalStateException("Cannot open a closed shopping cart");
+    }
+    return new ShoppingCartOpened(
+      shoppingCartId,
+      clientId
+    );
+  }
+
+  public static ProductItemAddedToShoppingCart addProductItem(
+    ShoppingCart shoppingCart,
+    ProductItem productItem,
+    ProductPriceCalculator productPriceCalculator
+  ) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Removing product item for cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    var pricedProductItem = productPriceCalculator.calculate(productItem);
+
+    shoppingCart.productItems().add(pricedProductItem);
+
+    return new ProductItemAddedToShoppingCart(
+      shoppingCart.id(),
+      pricedProductItem
+    );
+  }
+
+  public static ProductItemRemovedFromShoppingCart removeProductItem(ShoppingCart shoppingCart, PricedProductItem productItem) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Adding product item for cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    shoppingCart.productItems().hasEnough(productItem);
+
+    return new ProductItemRemovedFromShoppingCart(
+      shoppingCart.id(),
+      productItem
+    );
+  }
+
+  public static ShoppingCartConfirmed confirm(ShoppingCart shoppingCart) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Confirming cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    return new ShoppingCartConfirmed(
+      shoppingCart.id(),
+      OffsetDateTime.now()
+    );
+  }
+
+  public static ShoppingCartCanceled cancel(ShoppingCart shoppingCart) {
+    if (shoppingCart.isClosed())
+      throw new IllegalStateException("Canceling cart in '%s' status is not allowed.".formatted(shoppingCart.status()));
+
+    return new ShoppingCartCanceled(
+      shoppingCart.id(),
+      OffsetDateTime.now()
+    );
+  }
+
+  interface ProductPriceCalculator {
+    PricedProductItem calculate(ProductItem productItems);
+  }
+
+  static class FakeProductPriceCalculator implements ProductPriceCalculator {
+    private final double value;
+
+    private FakeProductPriceCalculator(double value) {
+      this.value = value;
+    }
+
+    public static FakeProductPriceCalculator returning(double value) {
+      return new FakeProductPriceCalculator(value);
+    }
+
+    public PricedProductItem calculate(ProductItem productItem) {
+      return new PricedProductItem(productItem.productId(), productItem.quantity(), value);
+    }
+  }
+
+
+  sealed public interface ShoppingCart {
+    UUID id();
+
+    UUID clientId();
+
+    ProductItems productItems();
+
+    record PendingShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems
+    ) implements ShoppingCart {
+    }
+
+    record ConfirmedShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime confirmedAt
+    ) implements ShoppingCart {
+    }
+
+    record CanceledShoppingCart(
+      UUID id,
+      UUID clientId,
+      ProductItems productItems,
+      OffsetDateTime canceledAt
+    ) implements ShoppingCart {
+    }
+
+    enum ShoppingCartStatus {
+      Pending,
+      Confirmed,
+      Canceled
+    }
+
+    default ShoppingCartStatus status() {
+      return switch (this) {
+        case PendingShoppingCart ignored:
+          yield ShoppingCartStatus.Pending;
+        case ConfirmedShoppingCart ignored:
+          yield ShoppingCartStatus.Confirmed;
+        case CanceledShoppingCart ignored:
+          yield ShoppingCartStatus.Canceled;
+      };
+    }
+
+    default boolean isClosed() {
+      return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
+    }
+
+    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+      return switch (event) {
+        case ShoppingCartOpened shoppingCartOpened:
+          yield new PendingShoppingCart(
+            shoppingCartOpened.shoppingCartId(),
+            shoppingCartOpened.clientId(),
+            ProductItems.empty()
+          );
+        case ProductItemAddedToShoppingCart productItemAddedToShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().add(productItemAddedToShoppingCart.productItem())
+          );
+        case ProductItemRemovedFromShoppingCart productItemRemovedFromShoppingCart:
+          yield new PendingShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems().remove(productItemRemovedFromShoppingCart.productItem())
+          );
+        case ShoppingCartConfirmed shoppingCartConfirmed:
+          yield new ConfirmedShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartConfirmed.confirmedAt()
+          );
+        case ShoppingCartCanceled shoppingCartCanceled:
+          yield new CanceledShoppingCart(
+            current.id(),
+            current.clientId(),
+            current.productItems(),
+            shoppingCartCanceled.canceledAt()
+          );
+      };
+    }
+
+    static ShoppingCart empty() {
+      return new PendingShoppingCart(null, null, null);
+    }
+  }
+
+  record ProductItem(UUID productId, int quantity) {
+  }
+
+  record PricedProductItem(UUID productId, int quantity, double unitPrice) {
+    public double totalAmount() {
+      return quantity * unitPrice;
+    }
+  }
+
+  record ProductItems(PricedProductItem[] values) {
+    public static ProductItems empty() {
+      return new ProductItems(new PricedProductItem[]{});
+    }
+
+
+    public ProductItems add(PricedProductItem productItem) {
+      // Note that we cannot simply group by product item id since the order of entries().stream().is arbitrary.
+      boolean containsProduct = Arrays.stream(values).anyMatch(pricedProductItem -> pricedProductItem.productId.equals(productItem.productId));
+      final Stream<PricedProductItem> resultingStream;
+      if (containsProduct) {
+        resultingStream = Arrays.stream(values)
+          .map(pricedProductItem -> new PricedProductItem(
+            pricedProductItem.productId,
+            pricedProductItem.quantity + productItem.quantity,
+            pricedProductItem.unitPrice));
+      } else {
+        resultingStream = StreamEx.of(values).append(productItem);
+      }
+      return new ProductItems(resultingStream.toArray(PricedProductItem[]::new));
+    }
+
+    public ProductItems remove(PricedProductItem productItem) {
+      return new ProductItems(
+        Arrays.stream(values())
+          .map(pi -> pi.productId().equals(productItem.productId()) ?
+            new PricedProductItem(
+              pi.productId(),
+              pi.quantity() - productItem.quantity(),
+              pi.unitPrice()
+            )
+            : pi
+          )
+          .filter(pi -> pi.quantity() > 0)
+          .toArray(PricedProductItem[]::new)
+      );
+    }
+
+    public boolean hasEnough(PricedProductItem productItem) {
+      var currentQuantity = Arrays.stream(values)
+        .filter(pi -> pi.productId().equals(productItem.productId()))
+        .mapToInt(PricedProductItem::quantity)
+        .sum();
+
+      return currentQuantity >= productItem.quantity();
+    }
+  }
+}
+

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/occurrent/immutable/OptimisticConcurrencyTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/occurrent/immutable/OptimisticConcurrencyTests.java
@@ -1,0 +1,128 @@
+package io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.cloudevents.CloudEvent;
+import io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.esdb.tools.EventStoreDBTest;
+import io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.FakeProductPriceCalculator;
+import io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.PricedProductItem;
+import io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.ProductItem;
+import io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.ShoppingCart.ShoppingCartStatus;
+import io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.ShoppingCartEvent;
+import one.util.streamex.StreamEx;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.api.WriteCondition;
+import org.occurrent.eventstore.api.WriteConditionNotFulfilledException;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.api.blocking.EventStore;
+import org.occurrent.eventstore.api.blocking.EventStream;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static io.eventdriven.introductiontoeventsourcing.e07_optimistic_concurrency.occurrent.immutable.BusinessLogic.ShoppingCart;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.occurrent.application.composition.command.partial.PartialFunctionApplication.partial;
+import static org.occurrent.eventstore.api.WriteCondition.streamVersionEq;
+import static org.occurrent.filter.Filter.streamId;
+
+public class OptimisticConcurrencyTests extends EventStoreDBTest {
+  private DomainEventQueries<ShoppingCartEvent> eventQueries;
+
+  private CustomApplicationService applicationService;
+
+  @BeforeEach
+  void setup() {
+    var objectMapper = new JsonMapper()
+      .registerModule(new JavaTimeModule())
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+    var eventStore = new InMemoryEventStore();
+    CloudEventConverter<ShoppingCartEvent> cloudEventConverter = new JacksonCloudEventConverter<>(objectMapper, URI.create("urn:eventsourcing:jvm:samples:occurrent"));
+    eventQueries = new DomainEventQueries<>(eventStore, cloudEventConverter);
+    applicationService = new CustomApplicationService(eventStore, cloudEventConverter);
+  }
+
+  @Test
+  public void gettingState_ForSequenceOfEvents_ShouldSucceed() throws InterruptedException {
+    var shoppingCartId = UUID.randomUUID();
+    var clientId = UUID.randomUUID();
+    var shoesId = UUID.randomUUID();
+    var tShirtId = UUID.randomUUID();
+
+    var twoPairsOfShoes = new ProductItem(shoesId, 2);
+    var tShirt = new ProductItem(tShirtId, 1);
+
+    var shoesPrice = 100;
+    var tShirtPrice = 50;
+
+    var pricedTwoPairOfShoes = new PricedProductItem(shoesId, 2, shoesPrice);
+
+    String streamId = "shopping_cart-%s".formatted(shoppingCartId);
+
+    // Open
+    applicationService.execute(streamId, evolveThenCall(partial(BusinessLogic::open, shoppingCartId, clientId)));
+
+    // Add two pairs of shoes
+    applicationService.execute(streamId, evolveThenCall(partial(BusinessLogic::addProductItem, twoPairsOfShoes, FakeProductPriceCalculator.returning(shoesPrice))));
+
+    // Add T-Shirt with wrong expected stream version
+    Throwable throwable = catchThrowable(() -> applicationService.execute(streamId, __ -> WriteCondition.streamVersionEq(1), evolveThenCall(partial(BusinessLogic::addProductItem, tShirt, FakeProductPriceCalculator.returning(tShirtPrice)))));
+
+    var shoppingCart = StreamEx.of(eventQueries.query(streamId(streamId))).foldLeft(ShoppingCart.empty(), ShoppingCart::when);
+
+    assertAll(
+      () -> assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class),
+      () -> assertThat(shoppingCart.id()).isEqualTo(shoppingCartId),
+      () -> assertThat(shoppingCart.clientId()).isEqualTo(clientId),
+      () -> assertThat(shoppingCart.status()).isEqualTo(ShoppingCartStatus.Pending),
+      () -> assertThat(shoppingCart.productItems().values()).containsExactly(pricedTwoPairOfShoes)
+    );
+  }
+
+
+  private static Function<Stream<ShoppingCartEvent>, Stream<ShoppingCartEvent>> evolveThenCall(Function<ShoppingCart, ShoppingCartEvent> domainMethod) {
+    return events -> {
+      ShoppingCart shoppingCart = StreamEx.of(events)
+        .foldLeft(ShoppingCart.empty(), ShoppingCart::when);
+      ShoppingCartEvent newEvent = domainMethod.apply(shoppingCart);
+      return Stream.of(newEvent);
+    };
+  }
+
+
+  private record CustomApplicationService(EventStore eventStore,
+                                          CloudEventConverter<ShoppingCartEvent> cloudEventConverter) implements ApplicationService<ShoppingCartEvent> {
+
+    @Override
+    public WriteResult execute(String streamId, Function<Stream<ShoppingCartEvent>, Stream<ShoppingCartEvent>> function,
+                               Consumer<Stream<ShoppingCartEvent>> __) {
+      return execute(streamId, cloudEvents -> streamVersionEq(cloudEvents.version()), function);
+    }
+
+    public WriteResult execute(String streamId, Function<EventStream<CloudEvent>, WriteCondition> writeConditionFunction, Function<Stream<ShoppingCartEvent>, Stream<ShoppingCartEvent>> function) {
+      EventStream<CloudEvent> eventStream = eventStore.read(streamId);
+      Stream<ShoppingCartEvent> eventsInStream = cloudEventConverter.toDomainEvents(eventStream.events());
+      Stream<ShoppingCartEvent> newDomainEvents = function.apply(eventsInStream);
+      Stream<CloudEvent> newEvents = cloudEventConverter.toCloudEvents(newDomainEvents);
+      return this.eventStore.write(streamId, writeConditionFunction.apply(eventStream), newEvents);
+    }
+  }
+}


### PR DESCRIPTION
This is an initial PR that adds examples for [Occurrent](https://occurrent.org/). I haven't spent much time with the docs since I'm not sure whether you like additional examples or not :) I've also used some high-level components from Occurrent that does some of the work on behalf of the user (such as the use of a [CloudEventConverter](https://occurrent.org/documentation#cloudevent-conversion) for Jackson to transform domain events to CloudEvents automatically and an [application service](https://occurrent.org/documentation#application-service) for writing domain events to the ES). Not sure if this is counter the purpose of the exercise, if so I can change the implementation to be closer to the ESDB examples. Feel free to simply ignore the PR if you don't like it. 