### PR TITLE
Upgraded packages to latest versions and ensured Java 18 compatibility

### DIFF
--- a/.github/workflows/samples_distributed-processes.yml
+++ b/.github/workflows/samples_distributed-processes.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/samples_event-sourcing-esdb-aggregates.yml
+++ b/.github/workflows/samples_event-sourcing-esdb-aggregates.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/samples_event-sourcing-esdb-simple.yml
+++ b/.github/workflows/samples_event-sourcing-esdb-simple.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/samples_event-stream-metadata.yml
+++ b/.github/workflows/samples_event-stream-metadata.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/samples_events-versioning.yml
+++ b/.github/workflows/samples_events-versioning.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/samples_uniqueness.yml
+++ b/.github/workflows/samples_uniqueness.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/workshops_introduction-to-event-sourcing-exercises.yml
+++ b/.github/workflows/workshops_introduction-to-event-sourcing-exercises.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/workshops_introduction-to-event-sourcing-solved.yml
+++ b/.github/workflows/workshops_introduction-to-event-sourcing-solved.yml
@@ -20,6 +20,11 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # define the test matrix
+      matrix:
+        java-version: [17, 18]
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
@@ -27,10 +32,10 @@ jobs:
       - name: Start containers
         run: docker-compose up -d
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
           cache: gradle
 

--- a/samples/distributed-processes/build.gradle
+++ b/samples/distributed-processes/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+
 
 repositories {
   mavenCentral()
@@ -12,27 +12,27 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
   // Logging
-  implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+  implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
-  implementation 'org.postgresql:postgresql:42.3.6'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
+  implementation 'org.postgresql:postgresql:42.5.0'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
   testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.0'
 }
 

--- a/samples/event-sourcing-esdb-aggregates/build.gradle
+++ b/samples/event-sourcing-esdb-aggregates/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 repositories {
   mavenCentral()
@@ -14,35 +13,35 @@ repositories {
 
 dependencies {
   // Spring Boot Web
-  implementation 'org.springframework.boot:spring-boot-starter-web:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-web:2.7.3'
   // Validation
-  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.3'
   // Retry policy
   implementation 'org.springframework.retry:spring-retry:1.3.3'
   // Swagger
-  implementation "org.springdoc:springdoc-openapi-ui:1.6.9"
+  implementation "org.springdoc:springdoc-openapi-ui:1.6.11"
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 
   // Log4J logging
-  implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.7.3'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
-  implementation 'org.postgresql:postgresql:42.3.6'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
+  implementation 'org.postgresql:postgresql:42.5.0'
   implementation 'junit:junit:4.13.2'
 
   // Test frameworks
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 }
 
 configurations {

--- a/samples/event-sourcing-esdb-simple/build.gradle
+++ b/samples/event-sourcing-esdb-simple/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 repositories {
   mavenCentral()
@@ -14,35 +13,35 @@ repositories {
 
 dependencies {
   // Spring Boot Web
-  implementation 'org.springframework.boot:spring-boot-starter-web:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-web:2.7.3'
   // Validation
-  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.3'
   // Retry policy
   implementation 'org.springframework.retry:spring-retry:1.3.3'
   // Swagger
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+  implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 
   // Log4J logging
-  implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.7.0'
+  implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.7.3'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
-  implementation 'org.postgresql:postgresql:42.3.6'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
+  implementation 'org.postgresql:postgresql:42.5.0'
   implementation 'junit:junit:4.13.2'
 
   // Test frameworks
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 }
 
 configurations {

--- a/samples/events-versioning/build.gradle
+++ b/samples/events-versioning/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 repositories {
   mavenCentral()
@@ -12,23 +11,23 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
   // Logging
-  implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+  implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 }
 
 tasks.named('test') {

--- a/samples/stream-metadata/build.gradle
+++ b/samples/stream-metadata/build.gradle
@@ -11,9 +11,9 @@ repositories {
 
 dependencies {
     implementation 'com.eventstore:db-client-java:3.0.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 }
 
 test {

--- a/samples/uniqueness/build.gradle
+++ b/samples/uniqueness/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 repositories {
   mavenCentral()
@@ -12,27 +11,27 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
   // Logging
-  implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+  implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
-  implementation 'org.postgresql:postgresql:42.3.6'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
+  implementation 'org.postgresql:postgresql:42.5.0'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
   testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.0'
 }
 

--- a/workshops/introduction-to-event-sourcing/exercises/build.gradle
+++ b/workshops/introduction-to-event-sourcing/exercises/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 repositories {
   mavenCentral()
@@ -12,23 +11,23 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
   // Logging
-  implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+  implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 }
 
 tasks.named('test') {

--- a/workshops/introduction-to-event-sourcing/solved/build.gradle
+++ b/workshops/introduction-to-event-sourcing/solved/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 group = 'io.event-driven'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 repositories {
   mavenCentral()
@@ -12,23 +11,23 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
 
   // EventStoreDB client
   implementation 'com.eventstore:db-client-java:3.0.1'
 
   // Logging
-  implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+  implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
- Upgraded packages to the latest versions.
- Removed from the Gradle config `sourceCompatibility` to not restrict the code to Java 17.
- Updated GH Actions to run matrix build with Java 17 and 18.