### PR TITLE
Initial round of changes for Spring Boot 3 and EventStoreDB client 4 upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.5-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   eventstore.db:
     image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/distributed-processes/build.gradle
+++ b/samples/distributed-processes/build.gradle
@@ -12,11 +12,11 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -24,16 +24,16 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
-  implementation 'org.postgresql:postgresql:42.5.0'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.1'
+  implementation 'org.postgresql:postgresql:42.5.1'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
 }
 
 configurations {

--- a/samples/distributed-processes/docker-compose.yml
+++ b/samples/distributed-processes/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.5-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/distributed-processes/docker-compose.yml
+++ b/samples/distributed-processes/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   eventstore.db:
     image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/aggregates/AggregateStore.java
+++ b/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/aggregates/AggregateStore.java
@@ -3,8 +3,8 @@ package io.eventdriven.distributedprocesses.core.aggregates;
 import com.eventstore.dbclient.*;
 import io.eventdriven.distributedprocesses.core.http.ETag;
 import io.eventdriven.distributedprocesses.core.serialization.EventSerializer;
+import jakarta.persistence.EntityNotFoundException;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/aggregates/AggregateStore.java
+++ b/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/aggregates/AggregateStore.java
@@ -48,7 +48,7 @@ public class AggregateStore<Entity extends AbstractAggregate<Event, Id>, Event, 
   public ETag add(Entity entity) {
     return appendEvents(
       entity,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM)
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream())
     );
   }
 
@@ -86,7 +86,7 @@ public class AggregateStore<Entity extends AbstractAggregate<Event, Id>, Event, 
   private Optional<List<Event>> getEvents(String streamId) {
     ReadResult result;
     try {
-      result = eventStore.readStream(streamId).get();
+      result = eventStore.readStream(streamId, ReadStreamOptions.get()).get();
     } catch (Throwable e) {
       Throwable innerException = e.getCause();
 

--- a/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/esdb/subscriptions/SubscribeToAllOptionsFactory.java
+++ b/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/esdb/subscriptions/SubscribeToAllOptionsFactory.java
@@ -7,6 +7,6 @@ import io.eventdriven.distributedprocesses.core.serialization.EventTypeMapper;
 public final class SubscribeToAllOptionsFactory {
   public static <EventType> SubscribeToAllOptions filterByType(Class<EventType> eventType) {
     return SubscribeToAllOptions.get()
-      .filter(SubscriptionFilter.newBuilder().withEventTypePrefix(EventTypeMapper.toName(eventType)).build());
+      .filter(SubscriptionFilter.newBuilder().addStreamNamePrefix(EventTypeMapper.toName(eventType)).build());
   }
 }

--- a/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/serialization/EventSerializer.java
+++ b/samples/distributed-processes/src/main/java/io/eventdriven/distributedprocesses/core/serialization/EventSerializer.java
@@ -42,13 +42,12 @@ public final class EventSerializer {
 
   public static <Command> EventData serialize(CommandEnvelope<Command> commandEnvelope) {
     try {
-      return new EventData(
-        UUID.randomUUID(),
-        EventTypeMapper.toName(commandEnvelope.getClass()),
-        "application/json",
-        mapper.writeValueAsBytes(commandEnvelope.data()),
-        mapper.writeValueAsBytes(commandEnvelope.metadata())
-      );
+      return EventDataBuilder.json(
+          EventTypeMapper.toName(commandEnvelope.getClass()),
+          mapper.writeValueAsBytes(commandEnvelope.data())
+        )
+        .metadataAsBytes(mapper.writeValueAsBytes(commandEnvelope.metadata()))
+        .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
@@ -93,7 +92,7 @@ public final class EventSerializer {
       var metadata = mapper.readValue(resolvedEvent.getEvent().getUserMetadata(), EventMetadata.class);
 
 
-      if(event == null)
+      if (event == null)
         return Optional.empty();
 
       return Optional.of(new EventEnvelope<>(event, metadata));
@@ -118,7 +117,7 @@ public final class EventSerializer {
       var metadata = mapper.readValue(resolvedEvent.getEvent().getUserMetadata(), CommandMetadata.class);
 
 
-      if(event == null)
+      if (event == null)
         return Optional.empty();
 
       return Optional.of(new CommandEnvelope<>(event, metadata));

--- a/samples/distributed-processes/src/test/java/io/eventdriven/distributedprocesses/shoppingcarts/ShoppingCartTests.java
+++ b/samples/distributed-processes/src/test/java/io/eventdriven/distributedprocesses/shoppingcarts/ShoppingCartTests.java
@@ -24,7 +24,7 @@ public class ShoppingCartTests {
     // This one should succeed as we don't have such stream yet
     eventStore.appendToStream(
       shoppingCartStreamId,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
       EventSerializer.serialize(shoppingCartOpened)
     ).get();
 
@@ -32,7 +32,7 @@ public class ShoppingCartTests {
     try {
       eventStore.appendToStream(
         shoppingCartStreamId,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
         EventSerializer.serialize(shoppingCartOpened)
       ).get();
     } catch (ExecutionException exception) {
@@ -43,7 +43,7 @@ public class ShoppingCartTests {
   private EventStoreDBClient eventStore;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     this.eventStore = EventStoreDBClient.create(settings);
   }

--- a/samples/event-sourcing-esdb-aggregates/build.gradle
+++ b/samples/event-sourcing-esdb-aggregates/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'org.springframework.boot' version '2.7.0'
-  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+  id 'org.springframework.boot' version '3.0.1'
+  id 'io.spring.dependency-management' version '1.1.0'
   id 'java'
 }
 
@@ -13,35 +13,35 @@ repositories {
 
 dependencies {
   // Spring Boot Web
-  implementation 'org.springframework.boot:spring-boot-starter-web:2.7.3'
+  implementation 'org.springframework.boot:spring-boot-starter-web:3.0.1'
   // Validation
-  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.3'
+  implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.1'
   // Retry policy
-  implementation 'org.springframework.retry:spring-retry:1.3.3'
+  implementation 'org.springframework.retry:spring-retry:2.0.0'
   // Swagger
-  implementation "org.springdoc:springdoc-openapi-ui:1.6.11"
+  implementation "org.springdoc:springdoc-openapi-ui:1.6.14"
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 
   // Log4J logging
-  implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.7.3'
+  implementation 'org.springframework.boot:spring-boot-starter-log4j2:3.0.1'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
-  implementation 'org.postgresql:postgresql:42.5.0'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.1'
+  implementation 'org.postgresql:postgresql:42.5.1'
   implementation 'junit:junit:4.13.2'
 
   // Test frameworks
-  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 configurations {

--- a/samples/event-sourcing-esdb-aggregates/docker-compose.yml
+++ b/samples/event-sourcing-esdb-aggregates/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.1-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All
@@ -29,7 +29,7 @@ services:
         target: /var/log/eventstore
     networks:
       - eventstore.db
-        
+
   #######################################################
   #  Postgres
   #######################################################

--- a/samples/event-sourcing-esdb-aggregates/docker-compose.yml
+++ b/samples/event-sourcing-esdb-aggregates/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   eventstore.db:
     image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/api/controller/ShoppingCartsController.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/api/controller/ShoppingCartsController.java
@@ -19,8 +19,8 @@ import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/api/requests/ShoppingCartsRequests.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/api/requests/ShoppingCartsRequests.java
@@ -2,7 +2,7 @@ package io.eventdriven.ecommerce.api.requests;
 
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public final class ShoppingCartsRequests {

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/aggregates/AggregateStore.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/aggregates/AggregateStore.java
@@ -4,7 +4,7 @@ import com.eventstore.dbclient.*;
 import io.eventdriven.ecommerce.core.http.ETag;
 import io.eventdriven.ecommerce.core.serialization.EventSerializer;
 
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class AggregateStore<Entity extends AbstractAggregate<Event, Id>, Event, 
   public ETag add(Entity entity) {
     return appendEvents(
       entity,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM)
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream())
     );
   }
 
@@ -70,7 +70,7 @@ public class AggregateStore<Entity extends AbstractAggregate<Event, Id>, Event, 
   private Optional<List<Event>> getEvents(String streamId) {
     ReadResult result;
     try {
-      result = eventStore.readStream(streamId).get();
+      result = eventStore.readStream(streamId, ReadStreamOptions.get()).get();
     } catch (Throwable e) {
       Throwable innerException = e.getCause();
 

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/aggregates/AggregateStore.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/aggregates/AggregateStore.java
@@ -101,9 +101,17 @@ public class AggregateStore<Entity extends AbstractAggregate<Event, Id>, Event, 
         events.iterator()
       ).get();
 
-      return ETag.weak(result.getNextExpectedRevision());
+      return toETag(result.getNextExpectedRevision());
     } catch (Throwable e) {
       throw new RuntimeException(e);
     }
+  }
+
+  //This ugly hack is needed as ESDB Java client from v4 doesn't allow to access or serialise version in an elegant manner
+  private ETag toETag(ExpectedRevision nextExpectedRevision) throws NoSuchFieldException, IllegalAccessException {
+    var field = nextExpectedRevision.getClass().getDeclaredField("version");
+    field.setAccessible(true);
+
+    return ETag.weak(field.get(nextExpectedRevision));
   }
 }

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/events/EventEnvelope.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/events/EventEnvelope.java
@@ -26,7 +26,7 @@ public record EventEnvelope<Event>(
         eventData.get(),
         new EventMetadata(
           resolvedEvent.getEvent().getEventId().toString(),
-          resolvedEvent.getEvent().getStreamRevision().getValueUnsigned(),
+          resolvedEvent.getEvent().getRevision(),
           resolvedEvent.getEvent().getPosition().getCommitUnsigned(),
           resolvedEvent.getEvent().getEventType()
         )

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/http/GlobalExceptionHandler.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/http/GlobalExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.RestClientException;
 
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/subscriptions/EventStoreDBSubscriptionCheckpointRepository.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/subscriptions/EventStoreDBSubscriptionCheckpointRepository.java
@@ -56,7 +56,7 @@ public final class EventStoreDBSubscriptionCheckpointRepository implements Subsc
       // store new checkpoint expecting stream to exist
       eventStore.appendToStream(
         streamName,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.STREAM_EXISTS),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.streamExists()),
         event
       ).get();
     } catch (Throwable e) {
@@ -73,14 +73,14 @@ public final class EventStoreDBSubscriptionCheckpointRepository implements Subsc
       try {
         eventStore.setStreamMetadata(
           streamName,
-          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.streamExists()),
           keepOnlyLastEvent
         ).get();
 
         // append event again expecting stream to not exist
         eventStore.appendToStream(
           streamName,
-          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
           event
         ).get();
       } catch (Exception exception) {

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/subscriptions/EventStoreDBSubscriptionCheckpointRepository.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/core/subscriptions/EventStoreDBSubscriptionCheckpointRepository.java
@@ -73,7 +73,7 @@ public final class EventStoreDBSubscriptionCheckpointRepository implements Subsc
       try {
         eventStore.setStreamMetadata(
           streamName,
-          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.streamExists()),
+          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
           keepOnlyLastEvent
         ).get();
 

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/ShoppingCartService.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/ShoppingCartService.java
@@ -14,7 +14,7 @@ import io.eventdriven.ecommerce.shoppingcarts.productitems.ProductItem;
 import org.springframework.data.domain.Page;
 import org.springframework.retry.support.RetryTemplate;
 
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 
 public class ShoppingCartService {

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetails.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetails.java
@@ -6,7 +6,7 @@ import io.eventdriven.ecommerce.core.events.EventMetadata;
 import io.eventdriven.ecommerce.core.views.VersionedView;
 import io.eventdriven.ecommerce.shoppingcarts.ShoppingCartStatus;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 import java.util.UUID;
 

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsProductItem.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsProductItem.java
@@ -1,8 +1,8 @@
 package io.eventdriven.ecommerce.shoppingcarts.gettingbyid;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import java.util.UUID;
 
 @Entity

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfo.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfo.java
@@ -6,7 +6,7 @@ import io.eventdriven.ecommerce.core.views.VersionedView;
 import io.eventdriven.ecommerce.shoppingcarts.ShoppingCartStatus;
 import io.eventdriven.ecommerce.shoppingcarts.productitems.PricedProductItem;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.UUID;
 
 @Entity

--- a/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfoRepository.java
+++ b/samples/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfoRepository.java
@@ -1,5 +1,6 @@
 package io.eventdriven.ecommerce.shoppingcarts.gettingcarts;
 
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +8,5 @@ import java.util.UUID;
 
 @Repository
 public interface ShoppingCartShortInfoRepository
-  extends PagingAndSortingRepository<ShoppingCartShortInfo, UUID> {
+  extends PagingAndSortingRepository<ShoppingCartShortInfo, UUID>, CrudRepository<ShoppingCartShortInfo, UUID> {
 }

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/AddProductItemToShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/AddProductItemToShoppingCartTests.java
@@ -48,7 +48,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(shoppingCartId), eTag))
+      .when(POST("/%s/products".formatted(shoppingCartId), eTag))
       .then(OK);
   }
 
@@ -66,7 +66,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(result.id()), result.eTag()))
+      .when(POST("/%s/products".formatted(result.id()), result.eTag()))
       .then(OK);
   }
 
@@ -87,7 +87,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(notExistingId), eTag))
+      .when(POST("/%s/products".formatted(notExistingId), eTag))
       .then(NOT_FOUND);
   }
 
@@ -102,7 +102,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(result.id()), result.eTag()))
+      .when(POST("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -117,7 +117,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(result.id()), result.eTag()))
+      .when(POST("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -126,7 +126,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
     var wrongETag = ETag.weak(999);
 
     given(() -> new AddProduct(new ProductItemRequest(UUID.randomUUID(), 2)))
-      .when(POST("%s/products".formatted(shoppingCartId), wrongETag))
+      .when(POST("/%s/products".formatted(shoppingCartId), wrongETag))
       .then(PRECONDITION_FAILED);
   }
 

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/ConfirmShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/ConfirmShoppingCartTests.java
@@ -54,10 +54,10 @@ public class ConfirmShoppingCartTests extends ApiSpecification {
   }
 
   @Test
-  public void confirm_fails_withMethodNotAllowed_forMissingShoppingCartId() {
+  public void confirm_fails_withNotFound_forMissingShoppingCartId() {
     given(() -> "")
       .when(PUT(eTag))
-      .then(METHOD_NOT_ALLOWED);
+      .then(NOT_FOUND);
   }
 
   @Test

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/OpenShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/OpenShoppingCartTests.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static io.eventdriven.ecommerce.testing.HttpEntityUtils.toHttpEntity;

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/RemoveProductItemFromShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/RemoveProductItemFromShoppingCartTests.java
@@ -49,14 +49,14 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
   @Test
   public void removeProductItem_succeeds_forNotAllProductsAndExistingShoppingCart() {
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity() - 1))
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(OK);
   }
 
   @Test
   public void removeProductItem_succeeds_forAllProductsAndExistingShoppingCart() {
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(OK);
   }
 
@@ -64,7 +64,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
   @MethodSource("invalidURLsProvider")
   public void removeProductItem_fails_withBadRequest_forInvalidURL(String invalidURL) {
     given(() -> invalidURL)
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(BAD_REQUEST);
   }
 
@@ -72,7 +72,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
   @Test
   public void removeProductItem_fails_withMethodNotAllowed_forMissingShoppingCartId() {
     given(() -> "")
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(METHOD_NOT_ALLOWED);
   }
 
@@ -81,7 +81,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
     var notExistingId = UUID.randomUUID();
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(notExistingId), eTag))
+      .when(DELETE("/%s/products".formatted(notExistingId), eTag))
       .then(NOT_FOUND);
   }
 
@@ -92,7 +92,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
         .build(cart -> cart.withClientId(clientId).confirmed());
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(result.id()), result.eTag()))
+      .when(DELETE("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -103,7 +103,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
         .build(builder -> builder.withClientId(clientId).canceled());
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(result.id()), result.eTag()))
+      .when(DELETE("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -112,7 +112,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
     var wrongETag = ETag.weak(999);
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(shoppingCartId), wrongETag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), wrongETag))
       .then(PRECONDITION_FAILED);
   }
 

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/builders/ShoppingCartRestBuilder.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/api/controller/builders/ShoppingCartRestBuilder.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ShoppingCartRestBuilder {
-  private final String apiPrefix = "api/shopping-carts/";
+  private final String apiPrefix = "api/shopping-carts";
   private final TestRestTemplate restTemplate;
   private final int port;
   private UUID clientId;
@@ -22,7 +22,7 @@ public class ShoppingCartRestBuilder {
   private final List<ProductItemRequest> products = new ArrayList<>();
 
   public String getApiUrl() {
-    return "http://localhost:%s/%s/".formatted(port, apiPrefix);
+    return "http://localhost:%s/%s".formatted(port, apiPrefix);
   }
 
   private ShoppingCartRestBuilder(TestRestTemplate restTemplate, int port) {
@@ -95,7 +95,7 @@ public class ShoppingCartRestBuilder {
     var location = locationHeader.toString();
 
     assertTrue(location.startsWith(apiPrefix));
-    var newId = assertDoesNotThrow(() -> UUID.fromString(location.substring(apiPrefix.length())));
+    var newId = assertDoesNotThrow(() -> UUID.fromString(location.substring(apiPrefix.length() + 1)));
 
     return getResult(response, newId);
   }
@@ -108,7 +108,7 @@ public class ShoppingCartRestBuilder {
     var request = new HttpEntity<>(new AddProduct(product), headers);
 
     var response = this.restTemplate
-      .postForEntity(getApiUrl() + "%s/products".formatted(result.id()), request, Void.class);
+      .postForEntity(getApiUrl() + "/%s/products".formatted(result.id()), request, Void.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     return getResult(response, result.id());
@@ -123,7 +123,7 @@ public class ShoppingCartRestBuilder {
     var request = new HttpEntity<Void>(null, headers);
 
     var response = this.restTemplate
-      .exchange(getApiUrl() + result.id(), HttpMethod.PUT, request, Void.class);
+      .exchange("%s/%s".formatted(getApiUrl(), result.id()), HttpMethod.PUT, request, Void.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     return getResult(response, result.id());
@@ -137,7 +137,7 @@ public class ShoppingCartRestBuilder {
     var request = new HttpEntity<Void>(null, headers);
 
     var response = this.restTemplate
-      .exchange(getApiUrl() + result.id(), HttpMethod.DELETE, request, Void.class);
+      .exchange("%s/%s".formatted(getApiUrl(), result.id()), HttpMethod.DELETE, request, Void.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     return getResult(response, result.id());

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
@@ -1,5 +1,6 @@
 package io.eventdriven.ecommerce.testing;
 
+
 import io.eventdriven.ecommerce.core.http.ETag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -28,7 +29,7 @@ public abstract class ApiSpecification {
   }
 
   public String getApiUrl() {
-    return "http://localhost:%s/%s/".formatted(port, apiPrefix);
+    return "http://localhost:%s/%s".formatted(port, apiPrefix);
   }
 
   public ApiSpecificationBuilder given(Supplier<Object> define) {
@@ -60,7 +61,7 @@ public abstract class ApiSpecification {
 
     return (api, request) -> this.restTemplate
       .exchange(
-        getApiUrl() + urlSuffix + request,
+        getApiUrl() + urlSuffix + (request != "" ? "/%s".formatted(request) : request),
         HttpMethod.GET,
         new HttpEntity<>(null, getIfNoneMatchHeader(eTag)),
         entityClass
@@ -94,7 +95,7 @@ public abstract class ApiSpecification {
   public BiFunction<TestRestTemplate, Object, ResponseEntity> PUT(String urlSuffix, ETag eTag, boolean withEmptyBody) {
     return (api, request) -> this.restTemplate
       .exchange(
-        getApiUrl() + urlSuffix + (withEmptyBody ? request : ""),
+        getApiUrl() + urlSuffix + (withEmptyBody ? "/%s".formatted(request) : ""),
         HttpMethod.PUT,
         new HttpEntity<>(!withEmptyBody ? request : null, getIfMatchHeader(eTag)),
         Void.class
@@ -108,7 +109,7 @@ public abstract class ApiSpecification {
   public BiFunction<TestRestTemplate, Object, ResponseEntity> DELETE(String urlSuffix, ETag eTag) {
     return (api, request) -> this.restTemplate
       .exchange(
-        getApiUrl() + urlSuffix + request,
+        getApiUrl() + urlSuffix + (request != "" ? "/%s".formatted(request) : request),
         HttpMethod.DELETE,
         new HttpEntity<>(null, getIfMatchHeader(eTag)),
         Void.class
@@ -144,7 +145,7 @@ public abstract class ApiSpecification {
 
   public Consumer<ResponseEntity> CREATED =
     response -> {
-      assertResponseStatus(HttpStatus.CREATED);
+      assertResponseStatus(HttpStatus.CREATED).accept(response);
 
       var locationHeader = response.getHeaders().getLocation();
 

--- a/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
+++ b/samples/event-sourcing-esdb-aggregates/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
@@ -1,10 +1,9 @@
 package io.eventdriven.ecommerce.testing;
 
-
 import io.eventdriven.ecommerce.core.http.ETag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.lang.Nullable;
 

--- a/samples/event-sourcing-esdb-simple/build.gradle
+++ b/samples/event-sourcing-esdb-simple/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   // Retry policy
   implementation 'org.springframework.retry:spring-retry:2.0.0'
   // Swagger
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
+  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
   // Serialisation
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 

--- a/samples/event-sourcing-esdb-simple/build.gradle
+++ b/samples/event-sourcing-esdb-simple/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'org.springframework.boot' version '2.7.0'
-  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+  id 'org.springframework.boot' version '3.0.1'
+  id 'io.spring.dependency-management' version '1.1.0'
   id 'java'
 }
 
@@ -13,35 +13,35 @@ repositories {
 
 dependencies {
   // Spring Boot Web
-  implementation 'org.springframework.boot:spring-boot-starter-web:2.7.3'
+  implementation 'org.springframework.boot:spring-boot-starter-web:3.0.1'
   // Validation
-  implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.3'
+  implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.1'
   // Retry policy
-  implementation 'org.springframework.retry:spring-retry:1.3.3'
+  implementation 'org.springframework.retry:spring-retry:2.0.0'
   // Swagger
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+  implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 
   // Log4J logging
-  implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.7.3'
+  implementation 'org.springframework.boot:spring-boot-starter-log4j2:3.0.1'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
-  implementation 'org.postgresql:postgresql:42.5.0'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.1'
+  implementation 'org.postgresql:postgresql:42.5.1'
   implementation 'junit:junit:4.13.2'
 
   // Test frameworks
-  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 configurations {

--- a/samples/event-sourcing-esdb-simple/docker-compose.yml
+++ b/samples/event-sourcing-esdb-simple/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.5-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/event-sourcing-esdb-simple/docker-compose.yml
+++ b/samples/event-sourcing-esdb-simple/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   eventstore.db:
     image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/api/controllers/ShoppingCartsCommandController.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/api/controllers/ShoppingCartsCommandController.java
@@ -15,13 +15,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
-import static com.eventstore.dbclient.ExpectedRevision.NO_STREAM;
+import static com.eventstore.dbclient.ExpectedRevision.noStream;
 import static com.eventstore.dbclient.ExpectedRevision.expectedRevision;
 import static io.eventdriven.ecommerce.shoppingcarts.ShoppingCartCommand.*;
 
@@ -50,7 +50,7 @@ class ShoppingCartsCommandController {
         cartId,
         request.clientId()
       ),
-      NO_STREAM
+      noStream()
     );
 
     return ResponseEntity

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/api/controllers/ShoppingCartsQueryController.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/api/controllers/ShoppingCartsQueryController.java
@@ -42,7 +42,6 @@ class ShoppingCartsQueryController {
     @PathVariable UUID id,
     @RequestHeader(name = HttpHeaders.IF_NONE_MATCH) @Parameter(in = ParameterIn.HEADER, schema = @Schema(type = "string")) @Nullable ETag ifNoneMatch
   ) {
-
     var result = handle(detailsRepository, new GetShoppingCartById(id, ifNoneMatch));
 
     return ResponseEntity

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/api/requests/ShoppingCartsRequests.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/api/requests/ShoppingCartsRequests.java
@@ -2,7 +2,7 @@ package io.eventdriven.ecommerce.api.requests;
 
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public final class ShoppingCartsRequests {

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/entities/CommandHandler.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/entities/CommandHandler.java
@@ -54,7 +54,7 @@ public class CommandHandler<Entity, Command, Event> {
         EventSerializer.serialize(event)
       ).get();
 
-      return ETag.weak(result.getNextExpectedRevision());
+      return toETag(result.getNextExpectedRevision());
     } catch (Throwable e) {
       throw new RuntimeException(e);
     }
@@ -97,5 +97,13 @@ public class CommandHandler<Entity, Command, Event> {
       .toList();
 
     return Optional.of(events);
+  }
+
+  //This ugly hack is needed as ESDB Java client from v4 doesn't allow to access or serialise version in an elegant manner
+  private ETag toETag(ExpectedRevision nextExpectedRevision) throws NoSuchFieldException, IllegalAccessException {
+    var field = nextExpectedRevision.getClass().getDeclaredField("version");
+    field.setAccessible(true);
+
+    return ETag.weak(field.get(nextExpectedRevision));
   }
 }

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/entities/CommandHandler.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/entities/CommandHandler.java
@@ -3,8 +3,8 @@ package io.eventdriven.ecommerce.core.entities;
 import com.eventstore.dbclient.*;
 import io.eventdriven.ecommerce.core.http.ETag;
 import io.eventdriven.ecommerce.core.serialization.EventSerializer;
+import jakarta.persistence.EntityNotFoundException;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -42,7 +42,7 @@ public class CommandHandler<Entity, Command, Event> {
     var streamId = mapToStreamId.apply(id);
     var entity = get(id);
 
-    if(entity.isEmpty() && !expectedRevision.equals(ExpectedRevision.NO_STREAM))
+    if(entity.isEmpty() && !expectedRevision.equals(ExpectedRevision.noStream()))
       throw new EntityNotFoundException();
 
     var event = handle.apply(command, entity.orElse(getDefault.get()));
@@ -80,7 +80,7 @@ public class CommandHandler<Entity, Command, Event> {
   private Optional<List<Event>> getEvents(String streamId) {
     ReadResult result;
     try {
-      result = eventStore.readStream(streamId).get();
+      result = eventStore.readStream(streamId, ReadStreamOptions.get()).get();
     } catch (Throwable e) {
       Throwable innerException = e.getCause();
 

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/events/EventEnvelope.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/events/EventEnvelope.java
@@ -26,7 +26,7 @@ public record EventEnvelope<Event>(
         eventData.get(),
         new EventMetadata(
           resolvedEvent.getEvent().getEventId().toString(),
-          resolvedEvent.getEvent().getStreamRevision().getValueUnsigned(),
+          resolvedEvent.getEvent().getRevision(),
           resolvedEvent.getEvent().getPosition().getCommitUnsigned(),
           resolvedEvent.getEvent().getEventType()
         )

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/http/GlobalExceptionHandler.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/http/GlobalExceptionHandler.java
@@ -2,13 +2,12 @@ package io.eventdriven.ecommerce.core.http;
 
 import com.eventstore.dbclient.StreamNotFoundException;
 import com.eventstore.dbclient.WrongExpectedVersionException;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.RestClientException;
-
-import javax.persistence.EntityNotFoundException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/subscriptions/EventStoreDBSubscriptionCheckpointRepository.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/core/subscriptions/EventStoreDBSubscriptionCheckpointRepository.java
@@ -56,7 +56,7 @@ public final class EventStoreDBSubscriptionCheckpointRepository implements Subsc
       // store new checkpoint expecting stream to exist
       eventStore.appendToStream(
         streamName,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.STREAM_EXISTS),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.streamExists()),
         event
       ).get();
     } catch (Throwable e) {
@@ -73,14 +73,14 @@ public final class EventStoreDBSubscriptionCheckpointRepository implements Subsc
       try {
         eventStore.setStreamMetadata(
           streamName,
-          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
           keepOnlyLastEvent
         ).get();
 
         // append event again expecting stream to not exist
         eventStore.appendToStream(
           streamName,
-          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+          AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
           event
         ).get();
       } catch (Exception exception) {

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/GetShoppingCartById.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/GetShoppingCartById.java
@@ -5,7 +5,7 @@ import io.eventdriven.ecommerce.core.http.ETag;
 import org.springframework.lang.Nullable;
 import org.springframework.retry.support.RetryTemplate;
 
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 
 public record GetShoppingCartById(

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetails.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetails.java
@@ -6,7 +6,7 @@ import io.eventdriven.ecommerce.core.events.EventMetadata;
 import io.eventdriven.ecommerce.core.views.VersionedView;
 import io.eventdriven.ecommerce.shoppingcarts.ShoppingCartStatus;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 import java.util.UUID;
 

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsProductItem.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsProductItem.java
@@ -1,8 +1,6 @@
 package io.eventdriven.ecommerce.shoppingcarts.gettingbyid;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.*;
 import java.util.UUID;
 
 @Entity

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfo.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfo.java
@@ -3,11 +3,10 @@ package io.eventdriven.ecommerce.shoppingcarts.gettingcarts;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.eventdriven.ecommerce.core.events.EventMetadata;
 import io.eventdriven.ecommerce.core.views.VersionedView;
-import io.eventdriven.ecommerce.shoppingcarts.ShoppingCart;
 import io.eventdriven.ecommerce.shoppingcarts.ShoppingCartStatus;
 import io.eventdriven.ecommerce.shoppingcarts.productitems.PricedProductItem;
+import jakarta.persistence.*;
 
-import javax.persistence.*;
 import java.util.UUID;
 
 @Entity

--- a/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfoRepository.java
+++ b/samples/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingcarts/ShoppingCartShortInfoRepository.java
@@ -1,5 +1,6 @@
 package io.eventdriven.ecommerce.shoppingcarts.gettingcarts;
 
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +8,5 @@ import java.util.UUID;
 
 @Repository
 public interface ShoppingCartShortInfoRepository
-  extends PagingAndSortingRepository<ShoppingCartShortInfo, UUID> {
+  extends PagingAndSortingRepository<ShoppingCartShortInfo, UUID>, CrudRepository<ShoppingCartShortInfo, UUID> {
 }

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/AddProductItemToShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/AddProductItemToShoppingCartTests.java
@@ -48,7 +48,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(shoppingCartId), eTag))
+      .when(POST("/%s/products".formatted(shoppingCartId), eTag))
       .then(OK);
   }
 
@@ -66,7 +66,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(result.id()), result.eTag()))
+      .when(POST("/%s/products".formatted(result.id()), result.eTag()))
       .then(OK);
   }
 
@@ -87,7 +87,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(notExistingId), eTag))
+      .when(POST("/%s/products".formatted(notExistingId), eTag))
       .then(NOT_FOUND);
   }
 
@@ -102,7 +102,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(result.id()), result.eTag()))
+      .when(POST("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -117,7 +117,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
         UUID.randomUUID(),
         2
       )))
-      .when(POST("%s/products".formatted(result.id()), result.eTag()))
+      .when(POST("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -126,7 +126,7 @@ public class AddProductItemToShoppingCartTests extends ApiSpecification {
     var wrongETag = ETag.weak(999);
 
     given(() -> new AddProduct(new ProductItemRequest(UUID.randomUUID(), 2)))
-      .when(POST("%s/products".formatted(shoppingCartId), wrongETag))
+      .when(POST("/%s/products".formatted(shoppingCartId), wrongETag))
       .then(PRECONDITION_FAILED);
   }
 

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/ConfirmShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/ConfirmShoppingCartTests.java
@@ -54,10 +54,10 @@ public class ConfirmShoppingCartTests extends ApiSpecification {
   }
 
   @Test
-  public void confirm_fails_withMethodNotAllowed_forMissingShoppingCartId() {
+  public void confirm_fails_withNotFound_forMissingShoppingCartId() {
     given(() -> "")
       .when(PUT(eTag))
-      .then(METHOD_NOT_ALLOWED);
+      .then(NOT_FOUND);
   }
 
   @Test

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/OpenShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/OpenShoppingCartTests.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static io.eventdriven.ecommerce.testing.HttpEntityUtils.toHttpEntity;

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/RemoveProductItemFromShoppingCartTests.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/RemoveProductItemFromShoppingCartTests.java
@@ -49,14 +49,14 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
   @Test
   public void removeProductItem_succeeds_forNotAllProductsAndExistingShoppingCart() {
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity() - 1))
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(OK);
   }
 
   @Test
   public void removeProductItem_succeeds_forAllProductsAndExistingShoppingCart() {
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(OK);
   }
 
@@ -64,7 +64,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
   @MethodSource("invalidURLsProvider")
   public void removeProductItem_fails_withBadRequest_forInvalidURL(String invalidURL) {
     given(() -> invalidURL)
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(BAD_REQUEST);
   }
 
@@ -72,7 +72,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
   @Test
   public void removeProductItem_fails_withMethodNotAllowed_forMissingShoppingCartId() {
     given(() -> "")
-      .when(DELETE("%s/products/".formatted(shoppingCartId), eTag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), eTag))
       .then(METHOD_NOT_ALLOWED);
   }
 
@@ -81,7 +81,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
     var notExistingId = UUID.randomUUID();
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(notExistingId), eTag))
+      .when(DELETE("/%s/products".formatted(notExistingId), eTag))
       .then(NOT_FOUND);
   }
 
@@ -92,7 +92,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
         .build(cart -> cart.withClientId(clientId).confirmed());
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(result.id()), result.eTag()))
+      .when(DELETE("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -103,7 +103,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
         .build(builder -> builder.withClientId(clientId).canceled());
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(result.id()), result.eTag()))
+      .when(DELETE("/%s/products".formatted(result.id()), result.eTag()))
       .then(CONFLICT);
   }
 
@@ -112,7 +112,7 @@ public class RemoveProductItemFromShoppingCartTests extends ApiSpecification {
     var wrongETag = ETag.weak(999);
 
     given(() -> "%s?price=%s&quantity=%s".formatted(product.getProductId(), product.getUnitPrice(), product.getQuantity()))
-      .when(DELETE("%s/products/".formatted(shoppingCartId), wrongETag))
+      .when(DELETE("/%s/products".formatted(shoppingCartId), wrongETag))
       .then(PRECONDITION_FAILED);
   }
 

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/builders/ShoppingCartRestBuilder.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/api/controller/builders/ShoppingCartRestBuilder.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ShoppingCartRestBuilder {
-  private final String apiPrefix = "api/shopping-carts/";
+  private final String apiPrefix = "api/shopping-carts";
   private final TestRestTemplate restTemplate;
   private final int port;
   private UUID clientId;
@@ -22,7 +22,7 @@ public class ShoppingCartRestBuilder {
   private final List<ProductItemRequest> products = new ArrayList<>();
 
   public String getApiUrl() {
-    return "http://localhost:%s/%s/".formatted(port, apiPrefix);
+    return "http://localhost:%s/%s".formatted(port, apiPrefix);
   }
 
   private ShoppingCartRestBuilder(TestRestTemplate restTemplate, int port) {
@@ -95,7 +95,7 @@ public class ShoppingCartRestBuilder {
     var location = locationHeader.toString();
 
     assertTrue(location.startsWith(apiPrefix));
-    var newId = assertDoesNotThrow(() -> UUID.fromString(location.substring(apiPrefix.length())));
+    var newId = assertDoesNotThrow(() -> UUID.fromString(location.substring(apiPrefix.length() + 1)));
 
     return getResult(response, newId);
   }
@@ -108,7 +108,7 @@ public class ShoppingCartRestBuilder {
     var request = new HttpEntity<>(new AddProduct(product), headers);
 
     var response = this.restTemplate
-      .postForEntity(getApiUrl() + "%s/products".formatted(result.id()), request, Void.class);
+      .postForEntity(getApiUrl() + "/%s/products".formatted(result.id()), request, Void.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     return getResult(response, result.id());
@@ -123,7 +123,7 @@ public class ShoppingCartRestBuilder {
     var request = new HttpEntity<Void>(null, headers);
 
     var response = this.restTemplate
-      .exchange(getApiUrl() + result.id(), HttpMethod.PUT, request, Void.class);
+      .exchange("%s/%s".formatted(getApiUrl(), result.id()), HttpMethod.PUT, request, Void.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     return getResult(response, result.id());
@@ -137,7 +137,7 @@ public class ShoppingCartRestBuilder {
     var request = new HttpEntity<Void>(null, headers);
 
     var response = this.restTemplate
-      .exchange(getApiUrl() + result.id(), HttpMethod.DELETE, request, Void.class);
+      .exchange("%s/%s".formatted(getApiUrl(), result.id()), HttpMethod.DELETE, request, Void.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     return getResult(response, result.id());

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
@@ -29,7 +29,7 @@ public abstract class ApiSpecification {
   }
 
   public String getApiUrl() {
-    return "http://localhost:%s/%s/".formatted(port, apiPrefix);
+    return "http://localhost:%s/%s".formatted(port, apiPrefix);
   }
 
   public ApiSpecificationBuilder given(Supplier<Object> define) {
@@ -61,7 +61,7 @@ public abstract class ApiSpecification {
 
     return (api, request) -> this.restTemplate
       .exchange(
-        getApiUrl() + urlSuffix + request,
+        getApiUrl() + urlSuffix + (request != "" ? "/%s".formatted(request) : request),
         HttpMethod.GET,
         new HttpEntity<>(null, getIfNoneMatchHeader(eTag)),
         entityClass
@@ -95,7 +95,7 @@ public abstract class ApiSpecification {
   public BiFunction<TestRestTemplate, Object, ResponseEntity> PUT(String urlSuffix, ETag eTag, boolean withEmptyBody) {
     return (api, request) -> this.restTemplate
       .exchange(
-        getApiUrl() + urlSuffix + (withEmptyBody ? request : ""),
+        getApiUrl() + urlSuffix + (withEmptyBody ? "/%s".formatted(request) : ""),
         HttpMethod.PUT,
         new HttpEntity<>(!withEmptyBody ? request : null, getIfMatchHeader(eTag)),
         Void.class
@@ -109,7 +109,7 @@ public abstract class ApiSpecification {
   public BiFunction<TestRestTemplate, Object, ResponseEntity> DELETE(String urlSuffix, ETag eTag) {
     return (api, request) -> this.restTemplate
       .exchange(
-        getApiUrl() + urlSuffix + request,
+        getApiUrl() + urlSuffix + (request != "" ? "/%s".formatted(request) : request),
         HttpMethod.DELETE,
         new HttpEntity<>(null, getIfMatchHeader(eTag)),
         Void.class
@@ -145,7 +145,7 @@ public abstract class ApiSpecification {
 
   public Consumer<ResponseEntity> CREATED =
     response -> {
-      assertResponseStatus(HttpStatus.CREATED);
+      assertResponseStatus(HttpStatus.CREATED).accept(response);
 
       var locationHeader = response.getHeaders().getLocation();
 

--- a/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
+++ b/samples/event-sourcing-esdb-simple/src/test/java/io/eventdriven/ecommerce/testing/ApiSpecification.java
@@ -4,7 +4,7 @@ package io.eventdriven.ecommerce.testing;
 import io.eventdriven.ecommerce.core.http.ETag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.lang.Nullable;
 

--- a/samples/events-versioning/build.gradle
+++ b/samples/events-versioning/build.gradle
@@ -11,11 +11,11 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -24,10 +24,10 @@ dependencies {
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 tasks.named('test') {

--- a/samples/events-versioning/docker-compose.yml
+++ b/samples/events-versioning/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.1-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/events-versioning/docker-compose.yml
+++ b/samples/events-versioning/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   eventstore.db:
     image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/events-versioning/src/test/java/io/eventdriven/eventsversioning/transformations/esdb/StreamTransformationsTests.java
+++ b/samples/events-versioning/src/test/java/io/eventdriven/eventsversioning/transformations/esdb/StreamTransformationsTests.java
@@ -204,13 +204,13 @@ public class StreamTransformationsTests {
     public List<com.eventstore.dbclient.EventData> serialize(EventEnvelope... events) {
       return Arrays.stream(events)
         .map(eventEnvelope ->
-          new com.eventstore.dbclient.EventData(
-            UUID.randomUUID(),
-            mapping.map(eventEnvelope.data().getClass()),
-            "application/json",
-            Serializer.serialize(eventEnvelope.data()),
-            Serializer.serialize(eventEnvelope.metadata())
-          )
+          EventDataBuilder
+            .json(
+              mapping.map(eventEnvelope.data().getClass()),
+              Serializer.serialize(eventEnvelope.data())
+            )
+            .metadataAsBytes(Serializer.serialize(eventEnvelope.metadata()))
+            .build()
         )
         .toList();
     }
@@ -289,7 +289,7 @@ public class StreamTransformationsTests {
 
     // When
     var readEvents =
-      this.eventStore.readStream("shopping_cart-%s".formatted(shoppingCardId)).get()
+      this.eventStore.readStream("shopping_cart-%s".formatted(shoppingCardId), ReadStreamOptions.get()).get()
         .getEvents()
         .toArray(ResolvedEvent[]::new);
 
@@ -327,7 +327,7 @@ public class StreamTransformationsTests {
   private EventStoreDBClient eventStore;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     this.eventStore = EventStoreDBClient.create(settings);
   }

--- a/samples/stream-metadata/build.gradle
+++ b/samples/stream-metadata/build.gradle
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.eventstore:db-client-java:3.0.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    implementation 'com.eventstore:db-client-java:4.0.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 test {

--- a/samples/stream-metadata/src/test/java/eventstore/StreamMetadataTests.java
+++ b/samples/stream-metadata/src/test/java/eventstore/StreamMetadataTests.java
@@ -15,7 +15,7 @@ public class StreamMetadataTests {
     private EventStoreDBClient eventStore;
 
     @BeforeEach
-    void beforeEach() throws ParseError {
+    void beforeEach() throws ConnectionStringParsingException {
         EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
         this.eventStore = EventStoreDBClient.create(settings);
     }
@@ -55,7 +55,7 @@ public class StreamMetadataTests {
         ///////////////////////////////////////////////////////////////////////////////////
         this.eventStore.appendToStream(streamName, orderInitiated, orderPaid).get();
 
-        var result = this.eventStore.readStream(streamName).get().getEvents();
+        var result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         // we should get both of them
         Assertions.assertEquals(2, result.size());
         Assertions.assertEquals(orderInitiated.getEventId(), result.get(0).getEvent().getEventId());
@@ -66,7 +66,7 @@ public class StreamMetadataTests {
         ///////////////////////////////////////////////////////////////////////////////////
         this.eventStore.appendToStream(streamName, orderShipped).get();
 
-        result = this.eventStore.readStream(streamName).get().getEvents();
+        result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         Assertions.assertEquals(2, result.size());
         Assertions.assertEquals(orderPaid.getEventId(), result.get(0).getEvent().getEventId());
         Assertions.assertEquals(orderShipped.getEventId(), result.get(1).getEvent().getEventId());
@@ -76,7 +76,7 @@ public class StreamMetadataTests {
         ///////////////////////////////////////////////////////////////////////////////////
         this.eventStore.appendToStream(streamName, orderClosed).get();
 
-        result = this.eventStore.readStream(streamName).get().getEvents();
+        result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         Assertions.assertEquals(2, result.size());
         Assertions.assertEquals(orderShipped.getEventId(), result.get(0).getEvent().getEventId());
         Assertions.assertEquals(orderClosed.getEventId(), result.get(1).getEvent().getEventId());
@@ -110,7 +110,7 @@ public class StreamMetadataTests {
         ///////////////////////////////////////////////////////////////////////////////////
         this.eventStore.appendToStream(streamName, orderInitiated, orderPaid).get();
 
-        var result = this.eventStore.readStream(streamName).get().getEvents();
+        var result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         // we should get both of them
         Assertions.assertEquals(2, result.size());
         Assertions.assertEquals(orderInitiated.getEventId(), result.get(0).getEvent().getEventId());
@@ -122,7 +122,7 @@ public class StreamMetadataTests {
 
         Thread.sleep(3000);
 
-        result = this.eventStore.readStream(streamName).get().getEvents();
+        result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         Assertions.assertEquals(0, result.size());
     }
 
@@ -153,7 +153,7 @@ public class StreamMetadataTests {
         ///////////////////////////////////////////////////////////////////////////////////
         this.eventStore.appendToStream(streamName, orderInitiated, orderPaid, orderShipped, orderClosed).get();
 
-        var result = this.eventStore.readStream(streamName).get().getEvents();
+        var result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         // we should get both of them
         Assertions.assertEquals(4, result.size());
         Assertions.assertEquals(orderInitiated.getEventId(), result.get(0).getEvent().getEventId());
@@ -173,7 +173,7 @@ public class StreamMetadataTests {
         // 3. Let's read events again, we should not see initiated and paid events
         ///////////////////////////////////////////////////////////////////////////////////
 
-        result = this.eventStore.readStream(streamName).get().getEvents();
+        result = this.eventStore.readStream(streamName, ReadStreamOptions.get()).get().getEvents();
         Assertions.assertEquals(2, result.size());
         Assertions.assertEquals(orderShipped.getEventId(), result.get(0).getEvent().getEventId());
         Assertions.assertEquals(orderClosed.getEventId(), result.get(1).getEvent().getEventId());

--- a/samples/talk/build.gradle
+++ b/samples/talk/build.gradle
@@ -11,11 +11,11 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -24,10 +24,10 @@ dependencies {
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 tasks.named('test') {

--- a/samples/talk/docker-compose.yml
+++ b/samples/talk/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.1-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/talk/src/test/java/io/eventdriven/shoppingcarts/ShoppingCartTests.java
+++ b/samples/talk/src/test/java/io/eventdriven/shoppingcarts/ShoppingCartTests.java
@@ -1,8 +1,8 @@
 package io.eventdriven.shoppingcarts;
 
+import com.eventstore.dbclient.ConnectionStringParsingException;
 import com.eventstore.dbclient.EventStoreDBClient;
 import com.eventstore.dbclient.EventStoreDBConnectionString;
-import com.eventstore.dbclient.ParseError;
 import io.eventdriven.shoppingcarts.productitems.PricedProductItem;
 import io.eventdriven.shoppingcarts.productitems.ProductItem;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +26,7 @@ public class ShoppingCartTests {
   private EventStoreDBClient eventStore;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     var settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     this.eventStore = EventStoreDBClient.create(settings);
   }

--- a/samples/uniqueness/build.gradle
+++ b/samples/uniqueness/build.gradle
@@ -11,11 +11,11 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -23,16 +23,16 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
 
   // Postgres and JPA for read models
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
-  implementation 'org.postgresql:postgresql:42.5.0'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.1'
+  implementation 'org.postgresql:postgresql:42.5.1'
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
 }
 
 configurations {

--- a/samples/uniqueness/docker-compose.yml
+++ b/samples/uniqueness/docker-compose.yml
@@ -5,9 +5,9 @@ services:
   #  EventStoreDB - Event Store
   #######################################################
   eventstore.db:
-    image: eventstore/eventstore:21.10.5-buster-slim
+    image: eventstore/eventstore:22.10.0-buster-slim
     # use this image if you're running ARM-based proc like Apple M1
-    # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+    # image: eventstore/eventstore:22.10.0-alpha-arm64v8
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All

--- a/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/esdb/EventStore.java
+++ b/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/esdb/EventStore.java
@@ -68,7 +68,7 @@ public class EventStore {
     try {
       eventStore.deleteStream(
         streamId,
-        DeleteStreamOptions.get().expectedRevision(ExpectedRevision.noStream())
+        DeleteStreamOptions.get().expectedRevision(ExpectedRevision.streamExists())
       ).get();
 
       return new DeleteResult.Success();

--- a/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/esdb/EventStore.java
+++ b/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/esdb/EventStore.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ExecutionException;
 public class EventStore {
   public ReadResult read(String streamId) {
     try {
-      var result = eventStore.readStream(streamId).get();
+      var result = eventStore.readStream(streamId, ReadStreamOptions.get()).get();
 
       return new ReadResult.Success(result.getEvents().toArray(new ResolvedEvent[0]));
     } catch (InterruptedException | ExecutionException e) {
@@ -29,7 +29,7 @@ public class EventStore {
     try {
       var result = eventStore.appendToStream(
         streamId,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
         eventsToAppend.iterator()
       ).get();
 
@@ -43,7 +43,7 @@ public class EventStore {
     }
   }
 
-  public AppendResult append(String streamId, StreamRevision expectedRevision, Object... events) {
+  public AppendResult append(String streamId, ExpectedRevision expectedRevision, Object... events) {
     try {
       var eventsToAppend = Arrays.stream(events)
         .map(EventSerializer::serialize)
@@ -68,7 +68,7 @@ public class EventStore {
     try {
       eventStore.deleteStream(
         streamId,
-        DeleteStreamOptions.get().expectedRevision(ExpectedRevision.STREAM_EXISTS)
+        DeleteStreamOptions.get().expectedRevision(ExpectedRevision.noStream())
       ).get();
 
       return new DeleteResult.Success();
@@ -80,7 +80,7 @@ public class EventStore {
     }
   }
 
-  public DeleteResult deleteStream(String streamId, StreamRevision expectedRevision) {
+  public DeleteResult deleteStream(String streamId, ExpectedRevision expectedRevision) {
     try {
       eventStore.deleteStream(
         streamId,
@@ -105,7 +105,7 @@ public class EventStore {
 
       var result = eventStore.setStreamMetadata(
         streamId,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
         metadata
       ).get();
 
@@ -147,14 +147,14 @@ public class EventStore {
 
   sealed public interface AppendResult {
     record Success(
-      StreamRevision nextExpectedRevision, Position logPosition) implements AppendResult {
+      ExpectedRevision nextExpectedRevision, Position logPosition) implements AppendResult {
     }
 
-    record StreamAlreadyExists(StreamRevision actual) implements AppendResult {
+    record StreamAlreadyExists(ExpectedRevision actual) implements AppendResult {
     }
 
-    record Conflict(StreamRevision expected,
-                    StreamRevision actual) implements AppendResult {
+    record Conflict(ExpectedRevision expected,
+                    ExpectedRevision actual) implements AppendResult {
     }
 
     record UnexpectedFailure(Throwable t) implements AppendResult {
@@ -172,8 +172,8 @@ public class EventStore {
     record StreamDoesNotExist() implements DeleteResult {
     }
 
-    record Conflict(StreamRevision expected,
-                    StreamRevision actual) implements DeleteResult {
+    record Conflict(ExpectedRevision expected,
+                    ExpectedRevision actual) implements DeleteResult {
     }
 
     record UnexpectedFailure(Throwable t) implements DeleteResult {

--- a/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/esdb/subscriptions/SubscribeToAllOptionsFactory.java
+++ b/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/esdb/subscriptions/SubscribeToAllOptionsFactory.java
@@ -7,6 +7,6 @@ import io.eventdriven.uniqueness.core.serialization.EventTypeMapper;
 public final class SubscribeToAllOptionsFactory {
   public static <EventType> SubscribeToAllOptions filterByType(Class<EventType> eventType) {
     return SubscribeToAllOptions.get()
-      .filter(SubscriptionFilter.newBuilder().withEventTypePrefix(EventTypeMapper.toName(eventType)).build());
+      .filter(SubscriptionFilter.newBuilder().addStreamNamePrefix(EventTypeMapper.toName(eventType)).build());
   }
 }

--- a/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/resourcereservation/esdb/ESDBResourceReservationHandler.java
+++ b/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/resourcereservation/esdb/ESDBResourceReservationHandler.java
@@ -1,7 +1,7 @@
 package io.eventdriven.uniqueness.core.resourcereservation.esdb;
 
 import com.eventstore.dbclient.AppendToStreamOptions;
-import com.eventstore.dbclient.StreamRevision;
+import com.eventstore.dbclient.ExpectedRevision;
 import io.eventdriven.uniqueness.core.esdb.EventStore;
 import io.eventdriven.uniqueness.core.processing.HandlerWithAck;
 import io.eventdriven.uniqueness.core.resourcereservation.ResourceReservationHandler;
@@ -92,7 +92,7 @@ public class ESDBResourceReservationHandler implements ResourceReservationHandle
     });
   }
 
-  private EventStore.AppendResult confirmReservation(String resourceKey, String reservationStreamId, StreamRevision expectedRevision) {
+  private EventStore.AppendResult confirmReservation(String resourceKey, String reservationStreamId, ExpectedRevision expectedRevision) {
     final var reservationConfirmed = new ResourceReservationConfirmed(
       resourceKey,
       OffsetDateTime.now()
@@ -106,7 +106,7 @@ public class ESDBResourceReservationHandler implements ResourceReservationHandle
     });
   }
 
-  private void markReservationAsReleased(String resourceKey, String reservationStreamId, StreamRevision expectedRevision) {
+  private void markReservationAsReleased(String resourceKey, String reservationStreamId, ExpectedRevision expectedRevision) {
     // We're marking reservation as to be released instead of deleting stream.
     // That's needed as if we'd delete stream here, then we wouldn't get event notification through subscriptions.
     // Because of that we wouldn't be able to clear the lookup for timed out reservations.

--- a/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/resourcereservation/jpa/ResourceReservation.java
+++ b/samples/uniqueness/src/main/java/io/eventdriven/uniqueness/core/resourcereservation/jpa/ResourceReservation.java
@@ -2,7 +2,7 @@ package io.eventdriven.uniqueness.core.resourcereservation.jpa;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.OffsetDateTime;
 
 @Entity

--- a/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/cinematickets/CinemaTicketTests.java
+++ b/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/cinematickets/CinemaTicketTests.java
@@ -30,7 +30,7 @@ public class CinemaTicketTests {
     // This one should succeed as we don't have such stream yet
     eventStore.appendToStream(
       seatReservationId,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
       serialize(new SeatReserved(ticketId, clientId, screeningId, seatId, price))
     ).get();
 
@@ -42,7 +42,7 @@ public class CinemaTicketTests {
 
       eventStore.appendToStream(
         seatReservationId,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
         serialize(new SeatReserved(otherTicketId, otherClientId, screeningId, seatId, price))
       ).get();
     } catch (ExecutionException exception) {
@@ -60,7 +60,7 @@ public class CinemaTicketTests {
     // We're simulating reservation that timed out because of e.g. not paying for it
     var nextExpectedRevision = eventStore.appendToStream(
       seatReservationId,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
       serialize(new SeatReserved(ticketId, clientId, screeningId, seatId, price)),
       reservationTimedOut
     ).get().getNextExpectedRevision();
@@ -74,7 +74,7 @@ public class CinemaTicketTests {
           // We'll use subscription, as we want to be sure that we'll release the reservation.
           // We'll subscribe only for the reservationTimedOut event, as it triggers release
           var filterReservationTimedOut = SubscribeToAllOptions.get()
-            .filter(SubscriptionFilter.newBuilder().withEventTypePrefix(reservationTimedOut.getEventType()).build());
+            .filter(SubscriptionFilter.newBuilder().addEventTypePrefix(reservationTimedOut.getEventType()).build());
           eventStore.subscribeToAll(new SubscriptionListener() {
             @Override
             public void onEvent(Subscription subscription, ResolvedEvent resolvedEvent) {
@@ -88,7 +88,7 @@ public class CinemaTicketTests {
                 // that marks where previous reservation has finished
                 eventStore.deleteStream(
                   seatReservationId,
-                  DeleteStreamOptions.get().expectedRevision(nextExpectedRevision).softDelete()
+                  DeleteStreamOptions.get().expectedRevision(nextExpectedRevision)
                 ).get();
 
                 // finish processing
@@ -111,7 +111,7 @@ public class CinemaTicketTests {
 
     eventStore.appendToStream(
       seatReservationId,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
       serialize(new SeatReserved(otherTicketId, otherClientId, screeningId, seatId, price))
     ).get();
   }
@@ -126,7 +126,7 @@ public class CinemaTicketTests {
   private double price = 123;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     this.eventStore = EventStoreDBClient.create(settings);
 

--- a/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/shoppingcarts/ShoppingCartTests.java
+++ b/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/shoppingcarts/ShoppingCartTests.java
@@ -24,7 +24,7 @@ public class ShoppingCartTests {
     // This one should succeed as we don't have such stream yet
     eventStore.appendToStream(
       shoppingCartStreamId,
-      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+      AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
       EventSerializer.serialize(shoppingCartOpened)
     ).get();
 
@@ -32,7 +32,7 @@ public class ShoppingCartTests {
     try {
       eventStore.appendToStream(
         shoppingCartStreamId,
-        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.NO_STREAM),
+        AppendToStreamOptions.get().expectedRevision(ExpectedRevision.noStream()),
         EventSerializer.serialize(shoppingCartOpened)
       ).get();
     } catch (ExecutionException exception) {
@@ -43,7 +43,7 @@ public class ShoppingCartTests {
   private EventStoreDBClient eventStore;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     this.eventStore = EventStoreDBClient.create(settings);
   }

--- a/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/users/UserEmailRegistrationFallbackTests.java
+++ b/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/users/UserEmailRegistrationFallbackTests.java
@@ -1,9 +1,9 @@
 package io.eventdriven.uniqueness.users;
 
+import com.eventstore.dbclient.ConnectionStringParsingException;
 import com.eventstore.dbclient.EventStoreDBClient;
 import com.eventstore.dbclient.EventStoreDBClientSettings;
 import com.eventstore.dbclient.EventStoreDBConnectionString;
-import com.eventstore.dbclient.ParseError;
 import io.eventdriven.uniqueness.core.async.SyncProcessor;
 import io.eventdriven.uniqueness.core.esdb.EventStore;
 import io.eventdriven.uniqueness.core.resourcereservation.Hash;
@@ -195,7 +195,7 @@ public class UserEmailRegistrationFallbackTests {
   private String reservationStreamId;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStoreDBClient = EventStoreDBClient.create(settings);
     eventStore = new EventStore(eventStoreDBClient);

--- a/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/users/UserEmailRegistrationScavengingTests.java
+++ b/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/users/UserEmailRegistrationScavengingTests.java
@@ -1,9 +1,9 @@
 package io.eventdriven.uniqueness.users;
 
+import com.eventstore.dbclient.ConnectionStringParsingException;
 import com.eventstore.dbclient.EventStoreDBClient;
 import com.eventstore.dbclient.EventStoreDBClientSettings;
 import com.eventstore.dbclient.EventStoreDBConnectionString;
-import com.eventstore.dbclient.ParseError;
 import io.eventdriven.uniqueness.core.esdb.EventStore;
 import io.eventdriven.uniqueness.core.resourcereservation.Hash;
 import io.eventdriven.uniqueness.core.resourcereservation.esdb.ESDBResourceReservationHandler;
@@ -119,7 +119,7 @@ public class UserEmailRegistrationScavengingTests {
   };
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     EventStoreDBClient eventStoreDBClient = EventStoreDBClient.create(settings);
     eventStore = new EventStore(eventStoreDBClient);

--- a/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/users/UserEmailRegistrationTests.java
+++ b/samples/uniqueness/src/test/java/io/eventdriven/uniqueness/users/UserEmailRegistrationTests.java
@@ -1,9 +1,9 @@
 package io.eventdriven.uniqueness.users;
 
+import com.eventstore.dbclient.ConnectionStringParsingException;
 import com.eventstore.dbclient.EventStoreDBClient;
 import com.eventstore.dbclient.EventStoreDBClientSettings;
 import com.eventstore.dbclient.EventStoreDBConnectionString;
-import com.eventstore.dbclient.ParseError;
 import io.eventdriven.uniqueness.core.esdb.EventStore;
 import io.eventdriven.uniqueness.core.resourcereservation.Hash;
 import io.eventdriven.uniqueness.core.resourcereservation.esdb.ESDBResourceReservationHandler;
@@ -79,7 +79,7 @@ public class UserEmailRegistrationTests {
   private UserCommandHandler userCommandHandler;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     var esdbClient = EventStoreDBClient.create(settings);
     eventStore = new EventStore(esdbClient);

--- a/workshops/introduction-to-event-sourcing/exercises/build.gradle
+++ b/workshops/introduction-to-event-sourcing/exercises/build.gradle
@@ -11,11 +11,11 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -24,10 +24,10 @@ dependencies {
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 tasks.named('test') {

--- a/workshops/introduction-to-event-sourcing/exercises/docker-compose.yml
+++ b/workshops/introduction-to-event-sourcing/exercises/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     #  EventStoreDB
     #######################################################
     eventstore.db:
-        image: eventstore/eventstore:21.10.5-buster-slim
+        image: eventstore/eventstore:22.10.0-buster-slim
         # use this image if you're running ARM-based proc like Apple M1
-        # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+        # image: eventstore/eventstore:22.10.0-alpha-arm64v8
         environment:
             - EVENTSTORE_CLUSTER_SIZE=1
             - EVENTSTORE_RUN_PROJECTIONS=All

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
@@ -62,7 +62,7 @@ public class AppendingEventsTests {
 
   @Tag("Exercise")
   @Test
-  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() throws ParseError {
+  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() throws ConnectionStringParsingException {
     var shoppingCartId = UUID.randomUUID();
     var clientId = UUID.randomUUID();
     var shoesId = UUID.randomUUID();
@@ -91,6 +91,6 @@ public class AppendingEventsTests {
       var result = appendEvents(eventStore, streamName, events).get();
       return result.getNextExpectedRevision();
     });
-    assertEquals(nextStreamRevision.getValueUnsigned(), events.length - 1);
+    assertEquals(nextStreamRevision, ExpectedRevision.expectedRevision(events.length - 1));
   }
 }

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/tools/EventStoreDBTest.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/tools/EventStoreDBTest.java
@@ -26,7 +26,7 @@ public abstract class EventStoreDBTest {
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStore = EventStoreDBClient.create(settings);
   }

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/tools/EventStoreDBTest.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/tools/EventStoreDBTest.java
@@ -26,7 +26,7 @@ public abstract class EventStoreDBTest {
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStore = EventStoreDBClient.create(settings);
   }

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/tools/EventStoreDBTest.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/tools/EventStoreDBTest.java
@@ -26,7 +26,7 @@ public abstract class EventStoreDBTest {
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStore = EventStoreDBClient.create(settings);
   }

--- a/workshops/introduction-to-event-sourcing/solved/build.gradle
+++ b/workshops/introduction-to-event-sourcing/solved/build.gradle
@@ -11,11 +11,11 @@ repositories {
 
 dependencies {
   // Serialisation
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
 
   // EventStoreDB client
-  implementation 'com.eventstore:db-client-java:3.0.1'
+  implementation 'com.eventstore:db-client-java:4.0.0'
 
   // Logging
   implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -24,10 +24,10 @@ dependencies {
 
   // Test frameworks
   implementation 'junit:junit:4.13.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
-  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.1'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
 }
 
 tasks.named('test') {

--- a/workshops/introduction-to-event-sourcing/solved/docker-compose.yml
+++ b/workshops/introduction-to-event-sourcing/solved/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     #  EventStoreDB
     #######################################################
     eventstore.db:
-        image: eventstore/eventstore:21.10.5-buster-slim
+        image: eventstore/eventstore:22.10.0-buster-slim
         # use this image if you're running ARM-based proc like Apple M1
-        # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
+        # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
         environment:
             - EVENTSTORE_CLUSTER_SIZE=1
             - EVENTSTORE_RUN_PROJECTIONS=All

--- a/workshops/introduction-to-event-sourcing/solved/docker-compose.yml
+++ b/workshops/introduction-to-event-sourcing/solved/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     eventstore.db:
         image: eventstore/eventstore:22.10.0-buster-slim
         # use this image if you're running ARM-based proc like Apple M1
-        # image: ghcr.io/eventstore/eventstore:22.10.0-alpha-arm64v8
+        # image: eventstore/eventstore:22.10.0-alpha-arm64v8
         environment:
             - EVENTSTORE_CLUSTER_SIZE=1
             - EVENTSTORE_RUN_PROJECTIONS=All

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
@@ -90,7 +90,7 @@ public class AppendingEventsTests {
   }
 
   @Test
-  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() throws ParseError {
+  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() throws ConnectionStringParsingException {
     var shoppingCartId = UUID.randomUUID();
     var clientId = UUID.randomUUID();
     var shoesId = UUID.randomUUID();
@@ -119,6 +119,6 @@ public class AppendingEventsTests {
       var result = appendEvents(eventStore, streamName, events).get();
       return result.getNextExpectedRevision();
     });
-    assertEquals(nextStreamRevision.getValueUnsigned(), events.length - 1);
+    assertEquals(nextStreamRevision, ExpectedRevision.expectedRevision(events.length - 1));
   }
 }

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution1/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution1/GettingStateFromEventsTests.java
@@ -1,6 +1,7 @@
 package io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.esdb.immutable.solution1;
 
 import com.eventstore.dbclient.EventStoreDBClient;
+import com.eventstore.dbclient.ReadStreamOptions;
 import com.eventstore.dbclient.ResolvedEvent;
 import io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.esdb.tools.EventStoreDBTest;
 import org.junit.jupiter.api.Test;
@@ -155,7 +156,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
   static List<ShoppingCartEvent> getEvents(EventStoreDBClient eventStore, String streamName) {
     // 1. Add logic here
     try {
-      return eventStore.readStream(streamName).get()
+      return eventStore.readStream(streamName, ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(GettingStateFromEventsTests::deserialize)
         .filter(ShoppingCartEvent.class::isInstance)

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution2/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution2/GettingStateFromEventsTests.java
@@ -1,6 +1,7 @@
 package io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.esdb.immutable.solution2;
 
 import com.eventstore.dbclient.EventStoreDBClient;
+import com.eventstore.dbclient.ReadStreamOptions;
 import com.eventstore.dbclient.ResolvedEvent;
 import io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.esdb.tools.EventStoreDBTest;
 import org.junit.jupiter.api.Test;
@@ -200,7 +201,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
   static <Event> Stream<Event> getEvents(Class<Event> eventClass, EventStoreDBClient eventStore, String streamName) {
     // 1. Add logic here
     try {
-      return eventStore.readStream(streamName).get()
+      return eventStore.readStream(streamName, ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(GettingStateFromEventsTests::deserialize)
         .filter(eventClass::isInstance)

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/mutable/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/mutable/GettingStateFromEventsTests.java
@@ -1,6 +1,7 @@
 package io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.esdb.mutable;
 
 import com.eventstore.dbclient.EventStoreDBClient;
+import com.eventstore.dbclient.ReadStreamOptions;
 import com.eventstore.dbclient.ResolvedEvent;
 import io.eventdriven.introductiontoeventsourcing.e04_getting_state_from_events.esdb.tools.EventStoreDBTest;
 import org.junit.jupiter.api.Test;
@@ -237,7 +238,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
   static ShoppingCart getShoppingCart(EventStoreDBClient eventStore, String streamName) {
     // 1. Add logic here
     try {
-      var events = eventStore.readStream(streamName).get()
+      var events = eventStore.readStream(streamName, ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(GettingStateFromEventsTests::deserialize)
         .filter(ShoppingCartEvent.class::isInstance)

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/tools/EventStoreDBTest.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/tools/EventStoreDBTest.java
@@ -26,7 +26,7 @@ public abstract class EventStoreDBTest {
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStore = EventStoreDBClient.create(settings);
   }

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/EntityStore.java
@@ -38,7 +38,7 @@ public final class EntityStore {
   ) {
     try {
       return Optional.of(
-        eventStore.readStream(streamName).get()
+        eventStore.readStream(streamName, ReadStreamOptions.get()).get()
           .getEvents().stream()
           .map(EntityStore::deserialize)
           .filter(eventClass::isInstance)

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/EntityStore.java
@@ -1,9 +1,6 @@
 package io.eventdriven.introductiontoeventsourcing.e06_business_logic.esdb.mixed;
 
-import com.eventstore.dbclient.EventData;
-import com.eventstore.dbclient.EventDataBuilder;
-import com.eventstore.dbclient.EventStoreDBClient;
-import com.eventstore.dbclient.ResolvedEvent;
+import com.eventstore.dbclient.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -51,7 +48,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event, Command> {
 
   public Entity get(UUID id) {
     try {
-      var events = eventStore.readStream(toStreamId.apply(id)).get()
+      var events = eventStore.readStream(toStreamId.apply(id), ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(EntityStore::deserialize)
         .filter(eventClass::isInstance)

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/EntityStore.java
@@ -1,9 +1,6 @@
 package io.eventdriven.introductiontoeventsourcing.e06_business_logic.esdb.mutable;
 
-import com.eventstore.dbclient.EventData;
-import com.eventstore.dbclient.EventDataBuilder;
-import com.eventstore.dbclient.EventStoreDBClient;
-import com.eventstore.dbclient.ResolvedEvent;
+import com.eventstore.dbclient.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -49,7 +46,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event> {
 
   public Entity get(UUID id) {
     try {
-      var events = eventStore.readStream(toStreamId.apply(id)).get()
+      var events = eventStore.readStream(toStreamId.apply(id), ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(EntityStore::deserialize)
         .filter(eventClass::isInstance)

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/tools/EventStoreDBTest.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/tools/EventStoreDBTest.java
@@ -26,7 +26,7 @@ public abstract class EventStoreDBTest {
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStore = EventStoreDBClient.create(settings);
   }

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/EntityStore.java
@@ -38,7 +38,7 @@ public final class EntityStore {
   ) {
     try {
       return Optional.of(
-        eventStore.readStream(streamName).get()
+        eventStore.readStream(streamName, ReadStreamOptions.get()).get()
           .getEvents().stream()
           .map(EntityStore::deserialize)
           .filter(eventClass::isInstance)
@@ -77,7 +77,7 @@ public final class EntityStore {
           eventStore,
           streamName,
           handle.apply(command, getEmpty.get()),
-          ExpectedRevision.NO_STREAM
+          ExpectedRevision.noStream()
         )
       );
   }

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/EntityStore.java
@@ -48,7 +48,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event, Command> {
 
   public Entity get(UUID id) {
     try {
-      var events = eventStore.readStream(toStreamId.apply(id)).get()
+      var events = eventStore.readStream(toStreamId.apply(id), ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(EntityStore::deserialize)
         .filter(eventClass::isInstance)
@@ -68,7 +68,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event, Command> {
   }
 
   public <C extends Command> void add(UUID id, Event event) {
-    store(id, event, ExpectedRevision.NO_STREAM);
+    store(id, event, ExpectedRevision.noStream());
   }
 
   public <C extends Command> void getAndUpdate(

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/EntityStore.java
@@ -46,7 +46,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event> {
 
   public Entity get(UUID id) {
     try {
-      var events = eventStore.readStream(toStreamId.apply(id)).get()
+      var events = eventStore.readStream(toStreamId.apply(id), ReadStreamOptions.get()).get()
         .getEvents().stream()
         .map(EntityStore::deserialize)
         .filter(eventClass::isInstance)
@@ -68,7 +68,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event> {
   }
 
   public void add(Entity entity) {
-    store(entity, ExpectedRevision.NO_STREAM);
+    store(entity, ExpectedRevision.noStream());
   }
 
   public <Command> void getAndUpdate(

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/tools/EventStoreDBTest.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/tools/EventStoreDBTest.java
@@ -26,7 +26,7 @@ public abstract class EventStoreDBTest {
       .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);;
 
   @BeforeEach
-  void beforeEach() throws ParseError {
+  void beforeEach() throws ConnectionStringParsingException {
     EventStoreDBClientSettings settings = EventStoreDBConnectionString.parse("esdb://localhost:2113?tls=false");
     eventStore = EventStoreDBClient.create(settings);
   }


### PR DESCRIPTION
- Updated to the Spring Boot 3.
- Migrated samples and workshops to EventStoreDB client v4 and EventStoreDB Docker image to 22.10 (the latest LTS).
- Bumped other dependencies.
