### PR TITLE
Used Events definition as Disciminated Union in exercises

### DIFF
--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
@@ -62,7 +62,7 @@ public class AppendingEventsTests {
 
   @Tag("Exercise")
   @Test
-  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() throws ConnectionStringParsingException {
+  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() {
     var shoppingCartId = UUID.randomUUID();
     var clientId = UUID.randomUUID();
     var shoesId = UUID.randomUUID();
@@ -71,7 +71,7 @@ public class AppendingEventsTests {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
         new ShoppingCartOpened(shoppingCartId, clientId),
         new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/GettingStateFromEventsTests.java
@@ -87,7 +87,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
         new ShoppingCartOpened(shoppingCartId, clientId),
         new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/mutable/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/mutable/GettingStateFromEventsTests.java
@@ -180,7 +180,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
         new ShoppingCartOpened(shoppingCartId, clientId),
         new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/immutable/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/immutable/BusinessLogicTests.java
@@ -139,7 +139,7 @@ public class BusinessLogicTests {
       };
     }
 
-    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+    static ShoppingCart evolve(ShoppingCart current, ShoppingCartEvent event) {
       return switch (event) {
         case ShoppingCartOpened shoppingCartOpened:
           yield new PendingShoppingCart(
@@ -192,7 +192,7 @@ public class BusinessLogicTests {
     return Arrays.stream(events)
       .filter(ShoppingCartEvent.class::isInstance)
       .map(ShoppingCartEvent.class::cast)
-      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::when));
+      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::evolve));
   }
 
   @Tag("Exercise")
@@ -208,7 +208,7 @@ public class BusinessLogicTests {
 
     // TODO: Fill the events object with results of your business logic
     // to be the same as events below
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
 //        new ShoppingCartEvent.ShoppingCartOpened(shoppingCartId, clientId),
 //        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/BusinessLogicTests.java
@@ -161,11 +161,8 @@ public class BusinessLogicTests {
       this.canceledAt = canceledAt;
     }
 
-    public void when(Object event) {
-      if (!(event instanceof ShoppingCartEvent shoppingCartEvent))
-        return;
-
-      switch (shoppingCartEvent) {
+    public void evolve(ShoppingCartEvent event) {
+      switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->
           apply(productItemAdded);
@@ -228,12 +225,12 @@ public class BusinessLogicTests {
     Canceled
   }
 
-  static ShoppingCart getShoppingCart(Object[] events) {
+  static ShoppingCart getShoppingCart(ShoppingCartEvent[] events) {
     // 1. Add logic here
     var shoppingCart = new ShoppingCart();
 
     for (var event : events) {
-      shoppingCart.when(event);
+      shoppingCart.evolve(event);
     }
 
     return shoppingCart;
@@ -252,7 +249,7 @@ public class BusinessLogicTests {
 
     // TODO: Fill the events object with results of your business logic
     // to be the same as events below
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
 //        new ShoppingCartOpened(shoppingCartId, clientId),
 //        new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/BusinessLogicTests.java
@@ -160,7 +160,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
       return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
     }
 
-    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+    static ShoppingCart evolve(ShoppingCart current, ShoppingCartEvent event) {
       return switch (event) {
         case ShoppingCartOpened shoppingCartOpened:
           yield new PendingShoppingCart(
@@ -213,7 +213,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
     return Arrays.stream(events)
       .filter(ShoppingCartEvent.class::isInstance)
       .map(ShoppingCartEvent.class::cast)
-      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::when));
+      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::evolve));
   }
 
   @Tag("Exercise")
@@ -240,7 +240,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
         eventStore,
         ShoppingCart::empty,
         "shopping_cart-%s"::formatted,
-        ShoppingCart::when,
+        ShoppingCart::evolve,
         (command, entity) -> ShoppingCartCommandHandler.decide(
           () -> command instanceof ShoppingCartCommand.AddProductItemToShoppingCart addProduct ?
             FakeProductPriceCalculator.returning(addProduct.productItem() == twoPairsOfShoes ? shoesPrice : tShirtPrice)
@@ -279,7 +279,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
     var getResult = EntityStore.get(
       ShoppingCartEvent.class,
       eventStore,
-      ShoppingCart::when,
+      ShoppingCart::evolve,
       ShoppingCart::empty,
       "shopping_cart-%s".formatted(shoppingCartId)
     );

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/EntityStore.java
@@ -13,7 +13,7 @@ public final class EntityStore {
   public static <Entity, Event> Optional<Entity> get(
     Class<Event> eventClass,
     EventStoreDBClient eventStore,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     Supplier<Entity> getEmpty,
     String streamName
   ) {
@@ -24,7 +24,7 @@ public final class EntityStore {
   public static <Entity, Command, Event> void getAndUpdate(
     Class<Event> eventClass,
     EventStoreDBClient eventStore,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     Supplier<Entity> getEmpty,
     BiFunction<Command, Entity, Event> handle,
     String streamName,
@@ -39,7 +39,7 @@ public final class EntityStore {
     EventStoreDBClient eventStore,
     Supplier<Entity> getEmpty,
     Function<UUID, String> toStreamName,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     BiFunction<Command, Entity, Event> handle
   ) {
     return (id, command) -> {
@@ -48,7 +48,7 @@ public final class EntityStore {
       EntityStore.getAndUpdate(
         eventClass,
         eventStore,
-        when,
+        evolve,
         getEmpty,
         handle,
         streamName,

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/BusinessLogic.java
@@ -13,7 +13,7 @@ public class BusinessLogic {
   public interface Aggregate<ShoppingCartEvent> {
     UUID id();
 
-    void when(ShoppingCartEvent event);
+    void evolve(ShoppingCartEvent event);
   }
 
   public static class ShoppingCart implements Aggregate<ShoppingCartEvent> {
@@ -30,7 +30,7 @@ public class BusinessLogic {
     private ShoppingCart(
       ShoppingCartOpened event
     ) {
-      when(event);
+      evolve(event);
     }
 
     public static ShoppingCart empty(){
@@ -134,7 +134,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/BusinessLogic.java
@@ -24,11 +24,11 @@ public class BusinessLogic {
       return dequeuedEvents;
     }
 
-    public abstract void when(Event event);
+    public abstract void evolve(Event event);
 
     protected void enqueue(Event event) {
       uncommittedEvents.add(event);
-      when(event);
+      evolve(event);
     }
   }
 
@@ -140,7 +140,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/EntityStore.java
@@ -14,7 +14,7 @@ public final class EntityStore {
   public static <Entity, Event> Optional<Entity> get(
     Class<Event> eventClass,
     EventStoreDBClient eventStore,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     Supplier<Entity> getEmpty,
     String streamName
   ) {
@@ -25,7 +25,7 @@ public final class EntityStore {
   public static <Entity, Command, Event> void getAndUpdate(
     Class<Event> eventClass,
     EventStoreDBClient eventStore,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     Supplier<Entity> getEmpty,
     BiFunction<Command, Entity, Event> handle,
     String streamName,
@@ -41,7 +41,7 @@ public final class EntityStore {
     EventStoreDBClient eventStore,
     Supplier<Entity> getEmpty,
     Function<UUID, String> toStreamName,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     BiFunction<Command, Entity, Event> handle
   ) {
     return (id, command, expectedRevision) -> {
@@ -50,7 +50,7 @@ public final class EntityStore {
       EntityStore.getAndUpdate(
         eventClass,
         eventStore,
-        when,
+        evolve,
         getEmpty,
         handle,
         streamName,

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/OptimisticConcurrencyTests.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/OptimisticConcurrencyTests.java
@@ -163,7 +163,7 @@ public class OptimisticConcurrencyTests extends EventStoreDBTest {
       return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
     }
 
-    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+    static ShoppingCart evolve(ShoppingCart current, ShoppingCartEvent event) {
       return switch (event) {
         case ShoppingCartOpened shoppingCartOpened:
           yield new PendingShoppingCart(
@@ -216,7 +216,7 @@ public class OptimisticConcurrencyTests extends EventStoreDBTest {
     return Arrays.stream(events)
       .filter(ShoppingCartEvent.class::isInstance)
       .map(ShoppingCartEvent.class::cast)
-      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::when));
+      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::evolve));
   }
 
   @Tag("Exercise")
@@ -241,7 +241,7 @@ public class OptimisticConcurrencyTests extends EventStoreDBTest {
         eventStore,
         ShoppingCart::empty,
         "shopping_cart-%s"::formatted,
-        ShoppingCart::when,
+        ShoppingCart::evolve,
         (command, entity) -> ShoppingCartCommandHandler.decide(
           () -> command instanceof AddProductItemToShoppingCart addProduct ?
             FakeProductPriceCalculator.returning(addProduct.productItem() == twoPairsOfShoes ? shoesPrice : tShirtPrice)
@@ -271,7 +271,7 @@ public class OptimisticConcurrencyTests extends EventStoreDBTest {
     var getResult = EntityStore.get(
       ShoppingCartEvent.class,
       eventStore,
-      ShoppingCart::when,
+      ShoppingCart::evolve,
       ShoppingCart::empty,
       "shopping_cart-%s".formatted(shoppingCartId)
     );

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/BusinessLogic.java
@@ -13,7 +13,7 @@ public class BusinessLogic {
   public interface Aggregate<ShoppingCartEvent> {
     UUID id();
 
-    void when(ShoppingCartEvent event);
+    void evolve(ShoppingCartEvent event);
   }
 
   public static class ShoppingCart implements Aggregate<ShoppingCartEvent> {
@@ -30,7 +30,7 @@ public class BusinessLogic {
     private ShoppingCart(
       ShoppingCartOpened event
     ) {
-      when(event);
+      evolve(event);
     }
 
     public static ShoppingCart empty(){
@@ -134,7 +134,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/exercises/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/BusinessLogic.java
@@ -24,11 +24,11 @@ public class BusinessLogic {
       return dequeuedEvents;
     }
 
-    public abstract void when(Event event);
+    public abstract void evolve(Event event);
 
     protected void enqueue(Event event) {
       uncommittedEvents.add(event);
-      when(event);
+      evolve(event);
     }
   }
 
@@ -140,7 +140,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e01_events_definition/solution2/EventsDefinitionTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e01_events_definition/solution2/EventsDefinitionTests.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static io.eventdriven.introductiontoeventsourcing.e01_events_definition.solution2.EventsDefinitionTests.ShoppingCartEvent.ShoppingCartConfirmed.*;
+import static io.eventdriven.introductiontoeventsourcing.e01_events_definition.solution2.EventsDefinitionTests.ShoppingCartEvent.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EventsDefinitionTests {
@@ -188,7 +188,7 @@ public class EventsDefinitionTests {
     var clientId = UUID.randomUUID();
     var pairOfShoes = new PricedProductItem(UUID.randomUUID(), 1, 100);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
         new ShoppingCartOpened(shoppingCartId, clientId),
         new ProductItemAddedToShoppingCart(shoppingCartId, pairOfShoes),

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e02_getting_state_from_events/immutable/solution1/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e02_getting_state_from_events/immutable/solution1/GettingStateFromEventsTests.java
@@ -157,12 +157,12 @@ public class GettingStateFromEventsTests {
 
     var events = new ShoppingCartEvent[]
       {
-        new ShoppingCartEvent.ShoppingCartOpened(shoppingCartId, clientId),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
-        new ShoppingCartEvent.ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
-        new ShoppingCartEvent.ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
-        new ShoppingCartEvent.ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
+        new ShoppingCartOpened(shoppingCartId, clientId),
+        new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
+        new ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
+        new ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
+        new ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
+        new ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
       };
 
     var shoppingCart = getShoppingCart(events);

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e02_getting_state_from_events/immutable/solution2/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e02_getting_state_from_events/immutable/solution2/GettingStateFromEventsTests.java
@@ -204,14 +204,14 @@ public class GettingStateFromEventsTests {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
-        new ShoppingCartEvent.ShoppingCartOpened(shoppingCartId, clientId),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
-        new ShoppingCartEvent.ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
-        new ShoppingCartEvent.ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
-        new ShoppingCartEvent.ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
+        new ShoppingCartOpened(shoppingCartId, clientId),
+        new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
+        new ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
+        new ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
+        new ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
+        new ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
       };
 
     var shoppingCart = getShoppingCart(events);

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e02_getting_state_from_events/mutable/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e02_getting_state_from_events/mutable/GettingStateFromEventsTests.java
@@ -160,11 +160,8 @@ public class GettingStateFromEventsTests {
       this.canceledAt = canceledAt;
     }
 
-    public void evolve(Object event) {
-      if (!(event instanceof ShoppingCartEvent shoppingCartEvent))
-        return;
-
-      switch (shoppingCartEvent) {
+    public void evolve(ShoppingCartEvent event) {
+      switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->
           apply(productItemAdded);
@@ -264,7 +261,7 @@ public class GettingStateFromEventsTests {
     assertEquals(clientId, shoppingCart.clientId());
     assertEquals(2, shoppingCart.productItems().size());
 
-    assertEquals(shoesId, shoppingCart.productItems().get(0).productId());
+    assertEquals(shoesId, shoppingCart.productItems().getFirst().productId());
     assertEquals(pairOfShoes.quantity(), shoppingCart.productItems().get(0).quantity());
     assertEquals(pairOfShoes.unitPrice(), shoppingCart.productItems().get(0).unitPrice());
 

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e03_appending_event/esdb/AppendingEventsTests.java
@@ -90,7 +90,7 @@ public class AppendingEventsTests {
   }
 
   @Test
-  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() throws ConnectionStringParsingException {
+  public void AppendingEvents_ForSequenceOfEvents_ShouldSucceed() {
     var shoppingCartId = UUID.randomUUID();
     var clientId = UUID.randomUUID();
     var shoesId = UUID.randomUUID();
@@ -99,7 +99,7 @@ public class AppendingEventsTests {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
         new ShoppingCartOpened(shoppingCartId, clientId),
         new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution1/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution1/GettingStateFromEventsTests.java
@@ -187,14 +187,14 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
-        new ShoppingCartEvent.ShoppingCartOpened(shoppingCartId, clientId),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
-        new ShoppingCartEvent.ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
-        new ShoppingCartEvent.ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
-        new ShoppingCartEvent.ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
+        new ShoppingCartOpened(shoppingCartId, clientId),
+        new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
+        new ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
+        new ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
+        new ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
+        new ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
       };
 
     var streamName = "shopping_cart-%s".formatted(shoppingCartId);

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution2/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/immutable/solution2/GettingStateFromEventsTests.java
@@ -144,7 +144,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
       };
     }
 
-    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+    static ShoppingCart evolve(ShoppingCart current, ShoppingCartEvent event) {
       return switch (event) {
         case ShoppingCartOpened shoppingCartOpened:
           yield new PendingShoppingCart(
@@ -195,7 +195,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
   static ShoppingCart getShoppingCart(EventStoreDBClient eventStore, String streamName) {
     // 1. Add logic here
     return getEvents(ShoppingCartEvent.class, eventStore, streamName)
-      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::when));
+      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::evolve));
   }
 
   static <Event> Stream<Event> getEvents(Class<Event> eventClass, EventStoreDBClient eventStore, String streamName) {
@@ -231,14 +231,14 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
-        new ShoppingCartEvent.ShoppingCartOpened(shoppingCartId, clientId),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
-        new ShoppingCartEvent.ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
-        new ShoppingCartEvent.ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
-        new ShoppingCartEvent.ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
-        new ShoppingCartEvent.ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
+        new ShoppingCartOpened(shoppingCartId, clientId),
+        new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
+        new ProductItemAddedToShoppingCart(shoppingCartId, tShirt),
+        new ProductItemRemovedFromShoppingCart(shoppingCartId, pairOfShoes),
+        new ShoppingCartConfirmed(shoppingCartId, OffsetDateTime.now()),
+        new ShoppingCartCanceled(shoppingCartId, OffsetDateTime.now())
       };
 
     var streamName = "shopping_cart-%s".formatted(shoppingCartId);

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/mutable/GettingStateFromEventsTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e04_getting_state_from_events/esdb/mutable/GettingStateFromEventsTests.java
@@ -168,11 +168,8 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
       this.canceledAt = canceledAt;
     }
 
-    public void when(Object event) {
-      if (!(event instanceof ShoppingCartEvent shoppingCartEvent))
-        return;
-
-      switch (shoppingCartEvent) {
+    public void evolve(ShoppingCartEvent event) {
+      switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->
           apply(productItemAdded);
@@ -248,7 +245,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
       var shoppingCart = new ShoppingCart();
 
       for (var event : events) {
-        shoppingCart.when(event);
+        shoppingCart.evolve(event);
       }
 
       return shoppingCart;
@@ -277,7 +274,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
     var pairOfShoes = new PricedProductItem(shoesId, 1, 100);
     var tShirt = new PricedProductItem(tShirtId, 1, 50);
 
-    var events = new Object[]
+    var events = new ShoppingCartEvent[]
       {
         new ShoppingCartOpened(shoppingCartId, clientId),
         new ProductItemAddedToShoppingCart(shoppingCartId, twoPairsOfShoes),
@@ -297,7 +294,7 @@ public class GettingStateFromEventsTests extends EventStoreDBTest {
     assertEquals(clientId, shoppingCart.clientId());
     assertEquals(2, shoppingCart.productItems().size());
 
-    assertEquals(shoesId, shoppingCart.productItems().get(0).productId());
+    assertEquals(shoesId, shoppingCart.productItems().getFirst().productId());
     assertEquals(pairOfShoes.quantity(), shoppingCart.productItems().get(0).quantity());
     assertEquals(pairOfShoes.unitPrice(), shoppingCart.productItems().get(0).unitPrice());
 

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/immutable/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/immutable/BusinessLogicTests.java
@@ -161,7 +161,7 @@ public class BusinessLogicTests {
       return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
     }
 
-    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+    static ShoppingCart evolve(ShoppingCart current, ShoppingCartEvent event) {
       return switch (event) {
         case ShoppingCartOpened shoppingCartOpened:
           yield new PendingShoppingCart(
@@ -214,7 +214,7 @@ public class BusinessLogicTests {
     return Arrays.stream(events)
       .filter(ShoppingCartEvent.class::isInstance)
       .map(ShoppingCartEvent.class::cast)
-      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::when));
+      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::evolve));
   }
 
   @Test

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution1/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution1/BusinessLogic.java
@@ -24,11 +24,11 @@ public class BusinessLogic {
       return dequeuedEvents;
     }
 
-    public abstract void when(Event event);
+    public abstract void evolve(Event event);
 
     protected void enqueue(Event event) {
       uncommittedEvents.add(event);
-      when(event);
+      evolve(event);
     }
   }
 
@@ -140,7 +140,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution1/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution1/BusinessLogicTests.java
@@ -129,7 +129,7 @@ public class BusinessLogicTests {
     var shoppingCart = new ShoppingCart();
 
     for (var event : shoppingCartEvents) {
-      shoppingCart.when(event);
+      shoppingCart.evolve(event);
     }
 
     return shoppingCart;

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution2/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution2/BusinessLogic.java
@@ -13,7 +13,7 @@ public class BusinessLogic {
   public interface Aggregate<ShoppingCartEvent> {
     UUID id();
 
-    void when(ShoppingCartEvent event);
+    void evolve(ShoppingCartEvent event);
   }
 
   public static class ShoppingCart implements Aggregate<ShoppingCartEvent> {
@@ -30,7 +30,7 @@ public class BusinessLogic {
     private ShoppingCart(
       ShoppingCartOpened event
     ) {
-      when(event);
+      evolve(event);
     }
 
     public static SimpleEntry<ShoppingCartEvent, ShoppingCart> open(UUID shoppingCartId, UUID clientId) {
@@ -130,7 +130,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution2/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e05_business_logic/mutable/solution2/BusinessLogicTests.java
@@ -72,7 +72,7 @@ public class BusinessLogicTests {
     var shoppingCart = new ShoppingCart();
 
     for (var event : shoppingCartEvents) {
-      shoppingCart.when(event);
+      shoppingCart.evolve(event);
     }
 
     return shoppingCart;

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/BusinessLogicTests.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/immutable/BusinessLogicTests.java
@@ -159,7 +159,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
       return this instanceof ConfirmedShoppingCart || this instanceof CanceledShoppingCart;
     }
 
-    static ShoppingCart when(ShoppingCart current, ShoppingCartEvent event) {
+    static ShoppingCart evolve(ShoppingCart current, ShoppingCartEvent event) {
       return switch (event) {
         case ShoppingCartOpened shoppingCartOpened:
           yield new PendingShoppingCart(
@@ -212,7 +212,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
     return Arrays.stream(events)
       .filter(ShoppingCartEvent.class::isInstance)
       .map(ShoppingCartEvent.class::cast)
-      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::when));
+      .collect(foldLeft(ShoppingCart::empty, ShoppingCart::evolve));
   }
 
   @Test
@@ -238,7 +238,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
         eventStore,
         ShoppingCart::empty,
         "shopping_cart-%s"::formatted,
-        ShoppingCart::when,
+        ShoppingCart::evolve,
         (command, entity) -> ShoppingCartCommandHandler.decide(
           () -> command instanceof AddProductItemToShoppingCart addProduct ?
             FakeProductPriceCalculator.returning(addProduct.productItem() == twoPairsOfShoes ? shoesPrice : tShirtPrice)
@@ -277,7 +277,7 @@ public class BusinessLogicTests extends EventStoreDBTest {
     var getResult = EntityStore.get(
       ShoppingCartEvent.class,
       eventStore,
-      ShoppingCart::when,
+      ShoppingCart::evolve,
       ShoppingCart::empty,
       "shopping_cart-%s".formatted(shoppingCartId)
     );

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/BusinessLogic.java
@@ -13,7 +13,7 @@ public class BusinessLogic {
   public interface Aggregate<ShoppingCartEvent> {
     UUID id();
 
-    void when(ShoppingCartEvent event);
+    void evolve(ShoppingCartEvent event);
   }
 
   public static class ShoppingCart implements Aggregate<ShoppingCartEvent> {
@@ -30,7 +30,7 @@ public class BusinessLogic {
     private ShoppingCart(
       ShoppingCartOpened event
     ) {
-      when(event);
+      evolve(event);
     }
 
     public static ShoppingCart empty(){
@@ -134,7 +134,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mixed/EntityStore.java
@@ -58,7 +58,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event, Command> {
       var entity = getEmpty.get();
 
       for (var event : events) {
-        entity.when(event);
+        entity.evolve(event);
       }
 
       return entity;

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/BusinessLogic.java
@@ -24,11 +24,11 @@ public class BusinessLogic {
       return dequeuedEvents;
     }
 
-    public abstract void when(Event event);
+    public abstract void evolve(Event event);
 
     protected void enqueue(Event event) {
       uncommittedEvents.add(event);
-      when(event);
+      evolve(event);
     }
   }
 
@@ -140,7 +140,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e06_business_logic/esdb/mutable/EntityStore.java
@@ -56,7 +56,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event> {
       var entity = entityClass.getDeclaredConstructor().newInstance();
 
       for (var event : events) {
-        entity.when(event);
+        entity.evolve(event);
       }
 
       return entity;

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/immutable/EntityStore.java
@@ -32,7 +32,7 @@ public final class EntityStore {
   public static <Entity, Event> Optional<Entity> get(
     Class<Event> eventClass,
     EventStoreDBClient eventStore,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     Supplier<Entity> getEmpty,
     String streamName
   ) {
@@ -43,7 +43,7 @@ public final class EntityStore {
           .map(EntityStore::deserialize)
           .filter(eventClass::isInstance)
           .map(eventClass::cast)
-          .collect(foldLeft(getEmpty, when))
+          .collect(foldLeft(getEmpty, evolve))
       );
     } catch (Throwable e) {
       Throwable innerException = e.getCause();
@@ -58,14 +58,14 @@ public final class EntityStore {
   public static <Entity, Command, Event> void getAndUpdate(
     Class<Event> eventClass,
     EventStoreDBClient eventStore,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     Supplier<Entity> getEmpty,
     BiFunction<Command, Entity, Event> handle,
     String streamName,
     Command command,
     Long expectedRevision
   ) {
-    get(eventClass, eventStore, when, getEmpty, streamName)
+    get(eventClass, eventStore, evolve, getEmpty, streamName)
       .ifPresentOrElse(
         current -> store(
           eventStore,
@@ -87,7 +87,7 @@ public final class EntityStore {
     EventStoreDBClient eventStore,
     Supplier<Entity> getEmpty,
     Function<UUID, String> toStreamName,
-    BiFunction<Entity, Event, Entity> when,
+    BiFunction<Entity, Event, Entity> evolve,
     BiFunction<Command, Entity, Event> handle
   ) {
     return (id, command, expectedRevision) -> {
@@ -96,7 +96,7 @@ public final class EntityStore {
       EntityStore.getAndUpdate(
         eventClass,
         eventStore,
-        when,
+        evolve,
         getEmpty,
         handle,
         streamName,

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/BusinessLogic.java
@@ -13,7 +13,7 @@ public class BusinessLogic {
   public interface Aggregate<ShoppingCartEvent> {
     UUID id();
 
-    void when(ShoppingCartEvent event);
+    void evolve(ShoppingCartEvent event);
   }
 
   public static class ShoppingCart implements Aggregate<ShoppingCartEvent> {
@@ -30,7 +30,7 @@ public class BusinessLogic {
     private ShoppingCart(
       ShoppingCartOpened event
     ) {
-      when(event);
+      evolve(event);
     }
 
     public static ShoppingCart empty(){
@@ -134,7 +134,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mixed/EntityStore.java
@@ -58,7 +58,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event, Command> {
       var entity = getEmpty.get();
 
       for (var event : events) {
-        entity.when(event);
+        entity.evolve(event);
       }
 
       return entity;

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/BusinessLogic.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/BusinessLogic.java
@@ -24,11 +24,11 @@ public class BusinessLogic {
       return dequeuedEvents;
     }
 
-    public abstract void when(Event event);
+    public abstract void evolve(Event event);
 
     protected void enqueue(Event event) {
       uncommittedEvents.add(event);
-      when(event);
+      evolve(event);
     }
   }
 
@@ -140,7 +140,7 @@ public class BusinessLogic {
     }
 
     @Override
-    public void when(ShoppingCartEvent event) {
+    public void evolve(ShoppingCartEvent event) {
       switch (event) {
         case ShoppingCartOpened opened -> apply(opened);
         case ProductItemAddedToShoppingCart productItemAdded ->

--- a/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/EntityStore.java
+++ b/workshops/introduction-to-event-sourcing/solved/src/test/java/io/eventdriven/introductiontoeventsourcing/e07_optimistic_concurrency/esdb/mutable/EntityStore.java
@@ -56,7 +56,7 @@ public class EntityStore<Entity extends Aggregate<Event>, Event> {
       var entity = entityClass.getDeclaredConstructor().newInstance();
 
       for (var event : events) {
-        entity.when(event);
+        entity.evolve(event);
       }
 
       return entity;


### PR DESCRIPTION
Replaced When method name into Evolve, as it's now more aligned with how people are doing it.